### PR TITLE
use dirname(@__FILE__) rather than Pkg.dir

### DIFF
--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -69,6 +69,6 @@ export tune!,
 # Plotting Facilities (loaded on demand) #
 ##########################################
 
-loadplotting() = include(joinpath(Pkg.dir("BenchmarkTools"), "src", "plotting.jl"))
+loadplotting() = include(joinpath(dirname(@__FILE__), "plotting.jl"))
 
 end # module BenchmarkTools


### PR DESCRIPTION
allows installing the package elsewhere


While I'm opening this and trying to familiarize myself with this code, the per-benchmark time tolerance probably doesn't need to be reported to `.00%` level of precision in the Nanosoldier reports. Where does that specific printing live?