### PR TITLE
Add support for assigning within benchmarked code block

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -195,6 +195,7 @@ macro benchmarkable(args...)
     deleteat!(params, delinds)
     vars = collectvars(setup)
     outvars = isa(core,Expr) ? collectvars(core) : []
+    outvars = filter(var -> var in vars, outvars)   # only return vars defined in setup
     if length(outvars) == 0
         returns = :(return)
     elseif length(outvars) == 1

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -148,8 +148,16 @@ function hasevals(params)
 end
 
 function collectvars(setup::Expr, vars::Vector{Symbol} = Symbol[])
-    if setup.head == :(=) && isa(first(setup.args), Symbol)
-        push!(vars, first(setup.args))
+    if setup.head == :(=)
+        lhs = first(setup.args)
+        if isa(lhs, Symbol)
+            push!(vars, lhs)
+        elseif isa(lhs, Expr) && lhs.head == :tuple
+            append!(vars, lhs.args)
+        end
+    elseif setup.head == :comprehension
+        arg = setup.args[1]
+        isa(arg, Expr) && collectvars(arg, vars)
     else
         for arg in setup.args
             isa(arg, Expr) && collectvars(arg, vars)

--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -120,6 +120,13 @@ tune!(b)
 @test foo.x == 1
 @test params(b).evals > 100
 
+@benchmark local_var="good" setup=(local_var="bad") teardown(@test local_var=="good")
+@test_throws UndefVarError local_var
+
+@benchmark some_var="whatever" teardown(@test_throws UndefVarError some_var)
+
+@benchmark foo,bar="good","good" setup=(foo="bad"; bar="bad") teardown=(@test foo=="good" && bar=="good")
+
 ########
 # misc #
 ########

--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -128,10 +128,12 @@ BenchmarkTools.DEFAULT_PARAMETERS.overhead = BenchmarkTools.estimate_overhead()
 # should theoretically be exactly 1, but this test is kind of volatile on Linux
 @test time(minimum(@benchmark nothing)) < 5
 
-@test [:x, :y, :z] == BenchmarkTools.collectvars(quote
+@test [:x, :y, :z, :v, :w] == BenchmarkTools.collectvars(quote
            x = 1 + 3
            y = 1 + x
            z = (a = 4; y + a)
+           v,w = 1,2
+           [u^2 for u in [1,2,3]]
        end)
 
 end # module


### PR DESCRIPTION
I would to be able to verify the result of a benchmark during tear-down. For example:

```julia
using BenchmarkTools
using Base.Test

@benchmark output=sin(input) setup=(
        input = rand(10);
        output = zeros(input)
    ) teardown=(
        @test_approx_eq output sin(input)
    )
```

Defining the `output` variable outside of the benchmark and trying to refer to it (ie. `$output=sin(input)`) doesn't work because of `$output` being replaced by the actual values instead of a variable reference: `invalid assignment location "Array{Float64, 1}[...]"`

So I've added support for returning values from the function wrapping the benchmark code. This PR consists of 2 parts, the first commit extending `collectvars` for parsing multiple assignments (as well as fixing a bug with comprehensions), the other commits adding and improving support for returning and assigning functions from the inner function wrapper.