### PR TITLE
fix various corner cases associated with keyword argument parsing and variable scoping

### DIFF
--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -120,12 +120,26 @@ tune!(b)
 @test foo.x == 1
 @test params(b).evals > 100
 
-@benchmark local_var="good" setup=(local_var="bad") teardown(@test local_var=="good")
+# test variable assignment with `@benchmark args...` form
+@benchmark local_var="good" setup=(local_var="bad") teardown=(@test local_var=="good")
 @test_throws UndefVarError local_var
-
-@benchmark some_var="whatever" teardown(@test_throws UndefVarError some_var)
-
+@benchmark some_var="whatever" teardown=(@test_throws UndefVarError some_var)
 @benchmark foo,bar="good","good" setup=(foo="bad"; bar="bad") teardown=(@test foo=="good" && bar=="good")
+
+# test variable assignment with `@benchmark(args...)` form
+@benchmark(local_var="good", setup=(local_var="bad"), teardown=(@test local_var=="good"))
+@test_throws UndefVarError local_var
+@benchmark(some_var="whatever", teardown=(@test_throws UndefVarError some_var))
+@benchmark((foo,bar) = ("good","good"), setup=(foo = "bad"; bar = "bad"), teardown=(@test foo == "good" && bar == "good"))
+
+# test kwargs separated by `,`
+@benchmark(output=sin(x), setup=(x=1.0; output=0.0), teardown=(@test output == sin(x)))
+
+# test kwargs separated by `;`
+@benchmark(output=sin(x); setup=(x=1.0; output=0.0), teardown=(@test output == sin(x)))
+
+# test kwargs separated by `,` and `;`
+@benchmark(output=sin(x), setup=(x=1.0; output=0.0); teardown=(@test output == sin(x)))
 
 ########
 # misc #


### PR DESCRIPTION
Noticed these corner cases after revisiting some of the keyword argument parsing code. An outline of this PR:

* kwargs to benchmark macros now parse correctly no matter what separator (`,` or `;`) is used
* fixes variable assignment in the core expression being parsed as kwargs
* prepend variable names in the sample function with "__" to decrease the chance of accidental name collision with variables introduced by the benchmarking expressions
* adds tests for some of the above