### PR TITLE
patch setup variable extraction to handle Julia v0.5's generator-based comprehensions

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -148,19 +148,19 @@ function hasevals(params)
     return false
 end
 
-function collectvars(setup::Expr, vars::Vector{Symbol} = Symbol[])
-    if setup.head == :(=)
-        lhs = first(setup.args)
+function collectvars(ex::Expr, vars::Vector{Symbol} = Symbol[])
+    if ex.head == :(=)
+        lhs = first(ex.args)
         if isa(lhs, Symbol)
             push!(vars, lhs)
         elseif isa(lhs, Expr) && lhs.head == :tuple
             append!(vars, lhs.args)
         end
-    elseif setup.head == :comprehension
-        arg = setup.args[1]
+    elseif (ex.head == :comprehension || ex.head == :generator)
+        arg = ex.args[1]
         isa(arg, Expr) && collectvars(arg, vars)
     else
-        for arg in setup.args
+        for arg in ex.args
             isa(arg, Expr) && collectvars(arg, vars)
         end
     end


### PR DESCRIPTION
Before this PR, iterator variables in comprehensions on v0.5 get incorrectly picked up by the setup variable extraction code:

```julia
# incorrect behavior on master
julia> BenchmarkTools.collectvars(:([u^2 for u in [1,2,3]]))
1-element Array{Symbol,1}:
 :u
```

After this PR:

```julia
# correct behavior
julia> BenchmarkTools.collectvars(:([u^2 for u in [1,2,3]]))
0-element Array{Symbol,1}
```
