### PR TITLE
Import Base.Iterators on v0.6

### DIFF
--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -8,6 +8,10 @@ if VERSION < v"0.5.0-dev+4305"
     Base.get(io::IO, setting::Symbol, default::Bool) = default
 end
 
+if VERSION >= v"0.6.0-dev.1015"
+  using Base.Iterators
+end
+
 const BENCHMARKTOOLS_VERSION = v"0.0.6"
 
 ##############


### PR DESCRIPTION
Otherwise a deprecation warning is printed at each iteration.

x-ref: https://github.com/JuliaLang/julia/pull/18839