### PR TITLE
re-enable JLD wrapper now that the scoping bug has been fixed

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
 Compat 0.8.0
-JLD 0.6.4
+JLD 0.6.6

--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -76,12 +76,6 @@ loadplotting() = include(joinpath(dirname(@__FILE__), "plotting.jl"))
 # Serialization #
 #################
 
-# Adds a compatibility fix for deserializing JLD files written with older versions of
-# BenchmarkTools. Unfortunately, this use of JLD.translate encounters a weird scoping bug
-# (see JuliaCI/BenchmarkTools.jl#23.). Even though it's currently unused, I've decided to
-# leave this code in the source tree for the time being, with the hope that a fix for
-# the scoping bug is pushed sometime soon.
-
-# include("serialization.jl")
+include("serialization.jl")
 
 end # module BenchmarkTools

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,8 +14,6 @@ print("Testing execution..."); tic()
 include("ExecutionTests.jl")
 println("done (took ", toq(), " seconds)")
 
-# This test fails due to a weird JLD scoping error. See JuliaCI/BenchmarkTools.jl#23.
-#
-# print("Testing serialization..."); tic()
-# include("SerializationTests.jl")
-# println("done (took ", toq(), " seconds)")
+print("Testing serialization..."); tic()
+include("SerializationTests.jl")
+println("done (took ", toq(), " seconds)")


### PR DESCRIPTION
Ref JuliaIO/JLD.jl#101. A new version of JLD will need to be tagged before tests will pass here (I bumped the required JLD version here to 0.6.6).

After this is merged, we can tag BenchmarkTools 0.0.6.