### PR TITLE
fix multiline show to follow documented API

### DIFF
--- a/src/groups.jl
+++ b/src/groups.jl
@@ -231,7 +231,7 @@ tagrepr(tags) = string("[", join(map(repr, tags), ", "), "]")
 
 Base.showall(io::IO, group::BenchmarkGroup) = @compat show(io, MIME"text/plain"(), group; verbose = true, limit = Inf)
 
-show(io::IO, group::BenchmarkGroup) = print(io, "$(length(group))-element BenchmarkGroup($(tagrepr(group.tags)))")
+Base.show(io::IO, group::BenchmarkGroup) = print(io, "$(length(group))-element BenchmarkGroup($(tagrepr(group.tags)))")
 
 @compat function Base.show(io::IO, mime::MIME"text/plain", group::BenchmarkGroup, pad = ""; verbose = false, limit = 10)
     println(io, "$(length(group))-element BenchmarkTools.BenchmarkGroup:")

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -229,53 +229,23 @@ Base.setindex!(group::BenchmarkGroup, v, k::BenchmarkGroup) = error("A Benchmark
 
 tagrepr(tags) = string("[", join(map(repr, tags), ", "), "]")
 
-Base.showall(io::IO, group::BenchmarkGroup) = show(io, group; verbose = true, limit = Inf)
+Base.showall(io::IO, group::BenchmarkGroup) = @compat show(io, MIME"text/plain"(), group; verbose = true, limit = Inf)
 
-# written this way for v0.5/v0.4 compatibility
-_showcompact(io::IO, group::BenchmarkGroup) = print(io, "$(length(group))-element BenchmarkGroup($(tagrepr(group.tags)))")
+show(io::IO, group::BenchmarkGroup) = print(io, "$(length(group))-element BenchmarkGroup($(tagrepr(group.tags)))")
 
-if VERSION < v"0.5.0-dev+4305"
-    Base.showcompact(io::IO, group::BenchmarkGroup) = _showcompact(io, group)
-    function Base.show(io::IO, group::BenchmarkGroup, pad = ""; verbose = false, limit = 10)
-        println(io, "$(length(group))-element BenchmarkTools.BenchmarkGroup:")
-        print(io, pad, "  tags: ", tagrepr(group.tags))
-        count = 1
-        for (k, v) in group
-            println(io)
-            print(io, pad, "  ", repr(k), " => ")
-            if verbose
-                if isa(v, BenchmarkGroup)
-                    show(io, v, "\t"*pad; verbose = verbose, limit = limit)
-                else
-                    show(io, v)
-                end
-            else
-                showcompact(io, v)
-            end
-            count > limit && (println(io); print(io, pad, "  ⋮"); break)
-            count += 1
-        end
-    end
-else
-    function Base.show(io::IO, group::BenchmarkGroup, pad = ""; verbose = false, limit = 10)
-        if get(io, :multiline, true)
-            println(io, "$(length(group))-element BenchmarkTools.BenchmarkGroup:")
-            print(io, pad, "  tags: ", tagrepr(group.tags))
-            count = 1
-            element_io = verbose ? io : IOContext(io, :multiline => false)
-            for (k, v) in group
-                println(io)
-                print(io, pad, "  ", repr(k), " => ")
-                if verbose && isa(v, BenchmarkGroup)
-                    show(element_io, v, "\t"*pad; verbose = verbose, limit = limit)
-                else
-                    show(element_io, v)
-                end
-                count > limit && (println(io); print(io, pad, "  ⋮"); break)
-                count += 1
-            end
+@compat function Base.show(io::IO, mime::MIME"text/plain", group::BenchmarkGroup, pad = ""; verbose = false, limit = 10)
+    println(io, "$(length(group))-element BenchmarkTools.BenchmarkGroup:")
+    print(io, pad, "  tags: ", tagrepr(group.tags))
+    count = 1
+    for (k, v) in group
+        println(io)
+        print(io, pad, "  ", repr(k), " => ")
+        if verbose && isa(v, BenchmarkGroup)
+            @compat show(io, mime, v, "\t"*pad; verbose = verbose, limit = limit)
         else
-            _showcompact(io, group)
+            show(io, v)
         end
+        count > limit && (println(io); print(io, pad, "  ⋮"); break)
+        count += 1
     end
 end

--- a/src/trials.jl
+++ b/src/trials.jl
@@ -262,10 +262,10 @@ function prettymemory(b)
     return string(@sprintf("%.2f", value), " ", units)
 end
 
-show(io::IO, t::Trial) = print(io, "Trial(", prettytime(time(t)), ")")
-show(io::IO, t::TrialEstimate) = print(io, "TrialEstimate(", prettytime(time(t)), ")")
-show(io::IO, t::TrialRatio) = print(io, "TrialRatio(", prettypercent(time(t)), ")")
-show(io::IO, t::TrialJudgement) = print(io, "TrialJudgement(", prettydiff(time(ratio(t))), " => ", time(t), ")")
+Base.show(io::IO, t::Trial) = print(io, "Trial(", prettytime(time(t)), ")")
+Base.show(io::IO, t::TrialEstimate) = print(io, "TrialEstimate(", prettytime(time(t)), ")")
+Base.show(io::IO, t::TrialRatio) = print(io, "TrialRatio(", prettypercent(time(t)), ")")
+Base.show(io::IO, t::TrialJudgement) = print(io, "TrialJudgement(", prettydiff(time(ratio(t))), " => ", time(t), ")")
 
 @compat function Base.show(io::IO, ::MIME"text/plain", t::Trial)
     if length(t) > 0

--- a/src/trials.jl
+++ b/src/trials.jl
@@ -262,93 +262,68 @@ function prettymemory(b)
     return string(@sprintf("%.2f", value), " ", units)
 end
 
-# written this way for v0.5/v0.4 compatibility
-_showcompact(io::IO, t::Trial) = print(io, "Trial(", prettytime(time(t)), ")")
-_showcompact(io::IO, t::TrialEstimate) = print(io, "TrialEstimate(", prettytime(time(t)), ")")
-_showcompact(io::IO, t::TrialRatio) = print(io, "TrialRatio(", prettypercent(time(t)), ")")
-_showcompact(io::IO, t::TrialJudgement) = print(io, "TrialJudgement(", prettydiff(time(ratio(t))), " => ", time(t), ")")
+show(io::IO, t::Trial) = print(io, "Trial(", prettytime(time(t)), ")")
+show(io::IO, t::TrialEstimate) = print(io, "TrialEstimate(", prettytime(time(t)), ")")
+show(io::IO, t::TrialRatio) = print(io, "TrialRatio(", prettypercent(time(t)), ")")
+show(io::IO, t::TrialJudgement) = print(io, "TrialJudgement(", prettydiff(time(ratio(t))), " => ", time(t), ")")
 
-if VERSION < v"0.5-"
-    Base.showcompact(io::IO, t::Trial) = _showcompact(io, t)
-    Base.showcompact(io::IO, t::TrialEstimate) = _showcompact(io, t)
-    Base.showcompact(io::IO, t::TrialRatio) = _showcompact(io, t)
-    Base.showcompact(io::IO, t::TrialJudgement) = _showcompact(io, t)
+@compat function Base.show(io::IO, ::MIME"text/plain", t::Trial)
+    if length(t) > 0
+        min = minimum(t)
+        max = maximum(t)
+        med = median(t)
+        avg = mean(t)
+        memorystr = string(prettymemory(memory(min)))
+        allocsstr = string(allocs(min))
+        minstr = string(prettytime(time(min)), " (", prettypercent(gcratio(min)), " GC)")
+        maxstr = string(prettytime(time(med)), " (", prettypercent(gcratio(med)), " GC)")
+        medstr = string(prettytime(time(avg)), " (", prettypercent(gcratio(avg)), " GC)")
+        meanstr = string(prettytime(time(max)), " (", prettypercent(gcratio(max)), " GC)")
+    else
+        memorystr = "N/A"
+        allocsstr = "N/A"
+        minstr = "N/A"
+        maxstr = "N/A"
+        medstr = "N/A"
+        meanstr = "N/A"
+    end
+    println(io, "BenchmarkTools.Trial: ")
+    println(io, "  memory estimate:  ", memorystr)
+    println(io, "  allocs estimate:  ", allocsstr)
+    println(io, "  --------------")
+    println(io, "  minimum time:     ", minstr)
+    println(io, "  median time:      ", maxstr)
+    println(io, "  mean time:        ", medstr)
+    println(io, "  maximum time:     ", meanstr)
+    println(io, "  --------------")
+    println(io, "  samples:          ", length(t))
+    println(io, "  evals/sample:     ", t.params.evals)
+    println(io, "  time tolerance:   ", prettypercent(params(t).time_tolerance))
+    print(io, "  memory tolerance: ", prettypercent(params(t).memory_tolerance))
 end
 
-function Base.show(io::IO, t::Trial)
-    if get(io, :multiline, true)
-        if length(t) > 0
-            min = minimum(t)
-            max = maximum(t)
-            med = median(t)
-            avg = mean(t)
-            memorystr = string(prettymemory(memory(min)))
-            allocsstr = string(allocs(min))
-            minstr = string(prettytime(time(min)), " (", prettypercent(gcratio(min)), " GC)")
-            maxstr = string(prettytime(time(med)), " (", prettypercent(gcratio(med)), " GC)")
-            medstr = string(prettytime(time(avg)), " (", prettypercent(gcratio(avg)), " GC)")
-            meanstr = string(prettytime(time(max)), " (", prettypercent(gcratio(max)), " GC)")
-        else
-            memorystr = "N/A"
-            allocsstr = "N/A"
-            minstr = "N/A"
-            maxstr = "N/A"
-            medstr = "N/A"
-            meanstr = "N/A"
-        end
-        println(io, "BenchmarkTools.Trial: ")
-        println(io, "  memory estimate:  ", memorystr)
-        println(io, "  allocs estimate:  ", allocsstr)
-        println(io, "  --------------")
-        println(io, "  minimum time:     ", minstr)
-        println(io, "  median time:      ", maxstr)
-        println(io, "  mean time:        ", medstr)
-        println(io, "  maximum time:     ", meanstr)
-        println(io, "  --------------")
-        println(io, "  samples:          ", length(t))
-        println(io, "  evals/sample:     ", t.params.evals)
-        println(io, "  time tolerance:   ", prettypercent(params(t).time_tolerance))
-        print(io, "  memory tolerance: ", prettypercent(params(t).memory_tolerance))
-
-    else
-        _showcompact(io, t)
-    end
+@compat function Base.show(io::IO, ::MIME"text/plain", t::TrialEstimate)
+    println(io, "BenchmarkTools.TrialEstimate: ")
+    println(io, "  time:             ", prettytime(time(t)))
+    println(io, "  gctime:           ", prettytime(gctime(t)), " (", prettypercent(gctime(t) / time(t)),")")
+    println(io, "  memory:           ", prettymemory(memory(t)))
+    println(io, "  allocs:           ", allocs(t))
+    println(io, "  time tolerance:   ", prettypercent(params(t).time_tolerance))
+    print(io,   "  memory tolerance: ", prettypercent(params(t).memory_tolerance))
 end
 
-function Base.show(io::IO, t::TrialEstimate)
-    if get(io, :multiline, true)
-        println(io, "BenchmarkTools.TrialEstimate: ")
-        println(io, "  time:             ", prettytime(time(t)))
-        println(io, "  gctime:           ", prettytime(gctime(t)), " (", prettypercent(gctime(t) / time(t)),")")
-        println(io, "  memory:           ", prettymemory(memory(t)))
-        println(io, "  allocs:           ", allocs(t))
-        println(io, "  time tolerance:   ", prettypercent(params(t).time_tolerance))
-        print(io,   "  memory tolerance: ", prettypercent(params(t).memory_tolerance))
-    else
-        _showcompact(io, t)
-    end
+@compat function Base.show(io::IO, ::MIME"text/plain", t::TrialRatio)
+    println(io, "BenchmarkTools.TrialRatio: ")
+    println(io, "  time:             ", time(t))
+    println(io, "  gctime:           ", gctime(t))
+    println(io, "  memory:           ", memory(t))
+    println(io, "  allocs:           ", allocs(t))
+    println(io, "  time tolerance:   ", prettypercent(params(t).time_tolerance))
+    print(io,   "  memory tolerance: ", prettypercent(params(t).memory_tolerance))
 end
 
-function Base.show(io::IO, t::TrialRatio)
-    if get(io, :multiline, true)
-        println(io, "BenchmarkTools.TrialRatio: ")
-        println(io, "  time:             ", time(t))
-        println(io, "  gctime:           ", gctime(t))
-        println(io, "  memory:           ", memory(t))
-        println(io, "  allocs:           ", allocs(t))
-        println(io, "  time tolerance:   ", prettypercent(params(t).time_tolerance))
-        print(io,   "  memory tolerance: ", prettypercent(params(t).memory_tolerance))
-    else
-        _showcompact(io, t)
-    end
-end
-
-function Base.show(io::IO, t::TrialJudgement)
-    if get(io, :multiline, true)
-        println(io, "BenchmarkTools.TrialJudgement: ")
-        println(io, "  time:   ", prettydiff(time(ratio(t))), " => ", time(t), " (", prettypercent(params(t).time_tolerance), " tolerance)")
-        print(io,   "  memory: ", prettydiff(memory(ratio(t))), " => ", memory(t), " (", prettypercent(params(t).memory_tolerance), " tolerance)")
-    else
-        _showcompact(io, t)
-    end
+@compat function Base.show(io::IO, ::MIME"text/plain", t::TrialJudgement)
+    println(io, "BenchmarkTools.TrialJudgement: ")
+    println(io, "  time:   ", prettydiff(time(ratio(t))), " => ", time(t), " (", prettypercent(params(t).time_tolerance), " tolerance)")
+    print(io,   "  memory: ", prettydiff(memory(ratio(t))), " => ", memory(t), " (", prettypercent(params(t).memory_tolerance), " tolerance)")
 end


### PR DESCRIPTION
This fixes `show` to use the [documented API in 0.6](http://docs.julialang.org/en/latest/manual/types.html#Custom-pretty-printing-1) for deciding on whether to use multiline output.  In particular, the three-argument `show(io, "text/plain", x)` indicates multiline output.   It should still be compatible with 0.4 via `@compat`, since 0.4 used `writemime` for the same effect.

(The `multiline` attribute was removed in JuliaLang/julia#17113, and never worked with IJulia.)