### PR TITLE
fix tests and doc in 0.6: semicolons no longer give macros keywords

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -203,12 +203,12 @@ Run a single evaluation of `x`. This can be useful if you think JIT overhead is 
 
 # Macros
 
-##### `@benchmarkable(expr; kwargs...)`
+##### `@benchmarkable(expr, kwargs...)`
 
 Define and return, but do not tune or run, a `Benchmark` that can be used to test the performance of `expr`. Relevant manual documentation can be found [here](manual.md#benchmarking-basics) (for valid `kwargs` values, see [here](manual.md#benchmark-parameters) specifically). If used in local scope, all
 external local variables must be interpolated.
 
-##### `@benchmark(expr; kwargs...)`
+##### `@benchmark(expr, kwargs...)`
 
 Define, tune, and run the `Benchmark` generated from `expr`. Relevant manual documentation can be found [here](manual.md#benchmarking-basics) (for valid `kwargs` values, see [here](manual.md#benchmark-parameters) specifically). If used in local scope, all external local variables must be interpolated.
 

--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -19,7 +19,7 @@ sizes = (5, 10, 20)
 for s in sizes
     A = rand(s, s)
     groups["sum"][s] = @benchmarkable sum($A) seconds=3
-    groups["sin"][s] = @benchmarkable(sin($s); seconds=1, gctrial=false)
+    groups["sin"][s] = @benchmarkable(sin($s), seconds=1, gctrial=false)
 end
 
 groups["special"]["macro"] = @benchmarkable @test(1 == 1)
@@ -134,12 +134,6 @@ tune!(b)
 
 # test kwargs separated by `,`
 @benchmark(output=sin(x), setup=(x=1.0; output=0.0), teardown=(@test output == sin(x)))
-
-# test kwargs separated by `;`
-@benchmark(output=sin(x); setup=(x=1.0; output=0.0), teardown=(@test output == sin(x)))
-
-# test kwargs separated by `,` and `;`
-@benchmark(output=sin(x), setup=(x=1.0; output=0.0); teardown=(@test output == sin(x)))
 
 ########
 # misc #


### PR DESCRIPTION
This fixes the tests to pass in JuliaLang/julia#7669