### PR TITLE
fix macro hygiene problems

### DIFF
--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -161,8 +161,10 @@ let fname = tempname()
         ret = open(fname, "w") do f
             redirect_stdout(f) do
                 x = 1
+                a = nothing
                 y = @btime(sin($x))
                 @test y == sin(1)
+                @test a === nothing
             end
         end
         s = readstring(fname)


### PR DESCRIPTION
This fixes #40 and some other hygiene problems (e.g. the macros were assuming that the local scope did not have a variable named `BenchmarkTools`).