### PR TITLE
loosen Compat version lower bound

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
-Compat 0.9.5
+Compat 0.9.0
 JLD 0.6.6


### PR DESCRIPTION
ref https://github.com/JuliaLang/METADATA.jl/pull/7682#discussion_r98323522
ref https://github.com/JuliaCI/BenchmarkTools.jl/pull/37#discussion_r99127203

@tkelman If this is a low enough bound, we can merge this and then I'll re-tag v0.0.7 in METADATA. I'd like to get Nanosoldier.jl running on current BenchmarkTools soon, which will require a tagged v0.0.7.