### PR TITLE
Define /(a::TrialEstimate, b::TrialEstimate) as a convenience

### DIFF
--- a/src/trials.jl
+++ b/src/trials.jl
@@ -171,6 +171,7 @@ function ratio(a::TrialEstimate, b::TrialEstimate)
     return TrialRatio(p, ratio(time(a), time(b)), ratio(gctime(a), gctime(b)),
                       ratio(memory(a), memory(b)), ratio(allocs(a), allocs(b)))
 end
+Base.:/(a::TrialEstimate, b::TrialEstimate) = ratio(a, b)
 
 gcratio(t::TrialEstimate) =  ratio(gctime(t), time(t))
 


### PR DESCRIPTION
It's a minor thing, but without it I'll have to special-case `TraceCalls.normalize`.