### PR TITLE
add quick start to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,35 @@ To install BenchmarkTools, you can run the following:
 Pkg.add("BenchmarkTools")
 ```
 
+## Quick Start
+
+The simplest usage is via the `@btime` macro, which is analogous to Julia's built-in [`@time` macro](https://docs.julialang.org/en/stable/stdlib/base/#Base.@time) but is often more accurate (by collecting results over multiple runs):
+
+```julia
+julia> using BenchmarkTools, Compat   # you need to use both modules
+
+julia> @btime sin(1)
+  15.081 ns (0 allocations: 0 bytes)
+0.8414709848078965
+```
+
+If the expression you want to benchmark depends on global variables, you should use `$` to "interpolate" them into the benchmark expression to [avoid the problems of benchmarking with globals](https://docs.julialang.org/en/stable/manual/performance-tips/#Avoid-global-variables-1).  Essentially, any interpolated variable `$x` or expression `$(...)` is "pre-computed" before benchmarking begins:
+
+```julia
+julia> A = rand(3,3);
+
+julia> @btime inv($A);            # we interpolate the global variable A with $A
+  1.191 μs (10 allocations: 2.31 KiB)
+  
+julia> @btime inv($(rand(3,3)));  # interpolation: the rand(3,3) call occurs before benchmarking
+  1.192 μs (10 allocations: 2.31 KiB)
+  
+julia> @btime inv(rand(3,3));     # the rand(3,3) call is included in the benchmark time
+  1.295 μs (11 allocations: 2.47 KiB)
+```
+
+As described the [manual](doc/manual.md), the BenchmarkTools package supports many other features, both for additional output and for more fine-grained control over the benchmarking process.
+
 ## Documentation
 
 If you're just getting started, check out the [manual](doc/manual.md) for a thorough explanation of BenchmarkTools.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pkg.add("BenchmarkTools")
 
 ## Quick Start
 
-The simplest usage is via the `@btime` macro, which is analogous to Julia's built-in [`@time` macro](https://docs.julialang.org/en/stable/stdlib/base/#Base.@time) but is often more accurate (by collecting results over multiple runs):
+The simplest usage is via the [`@btime` macro](https://github.com/JuliaCI/BenchmarkTools.jl/blob/master/doc/manual.md#benchmarking-basics), which is analogous to Julia's built-in [`@time` macro](https://docs.julialang.org/en/stable/stdlib/base/#Base.@time) but is often more accurate (by collecting results over multiple runs):
 
 ```julia
 julia> using BenchmarkTools, Compat   # you need to use both modules
@@ -29,7 +29,7 @@ julia> @btime sin(1)
 0.8414709848078965
 ```
 
-If the expression you want to benchmark depends on global variables, you should use `$` to "interpolate" them into the benchmark expression to [avoid the problems of benchmarking with globals](https://docs.julialang.org/en/stable/manual/performance-tips/#Avoid-global-variables-1).  Essentially, any interpolated variable `$x` or expression `$(...)` is "pre-computed" before benchmarking begins:
+If the expression you want to benchmark depends on external variables, you should use [`$` to "interpolate"](https://github.com/JuliaCI/BenchmarkTools.jl/blob/master/doc/manual.md#interpolating-values-into-benchmark-expressions) them into the benchmark expression to [avoid the problems of benchmarking with globals](https://docs.julialang.org/en/stable/manual/performance-tips/#Avoid-global-variables-1).  Essentially, any interpolated variable `$x` or expression `$(...)` is "pre-computed" before benchmarking begins:
 
 ```julia
 julia> A = rand(3,3);

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ To install BenchmarkTools, you can run the following:
 Pkg.add("BenchmarkTools")
 ```
 
+## Documentation
+
+If you're just getting started, check out the [manual](doc/manual.md) for a thorough explanation of BenchmarkTools.
+
+If you want to explore the BenchmarkTools API, see the [reference document](doc/reference.md).
+
+If you want a short example of a toy benchmark suite, see the sample file in this repo ([benchmark/benchmarks.jl](benchmark/benchmarks.jl)).
+
+If you want an extensive example of a benchmark suite being used in the real world, you can look at the source code of [BaseBenchmarks.jl](https://github.com/JuliaCI/BaseBenchmarks.jl/tree/nanosoldier).
+
+If you're benchmarking on Linux, I wrote up a series of [tips and tricks](https://github.com/JuliaCI/BenchmarkTools.jl/blob/master/doc/linuxtips.md) to help eliminate noise during performance tests.
+
 ## Quick Start
 
 The simplest usage is via the [`@btime` macro](https://github.com/JuliaCI/BenchmarkTools.jl/blob/master/doc/manual.md#benchmarking-basics), which is analogous to Julia's built-in [`@time` macro](https://docs.julialang.org/en/stable/stdlib/base/#Base.@time) but is often more accurate (by collecting results over multiple runs):
@@ -45,18 +57,6 @@ julia> @btime inv(rand(3,3));     # the rand(3,3) call is included in the benchm
 ```
 
 As described the [manual](doc/manual.md), the BenchmarkTools package supports many other features, both for additional output and for more fine-grained control over the benchmarking process.
-
-## Documentation
-
-If you're just getting started, check out the [manual](doc/manual.md) for a thorough explanation of BenchmarkTools.
-
-If you want to explore the BenchmarkTools API, see the [reference document](doc/reference.md).
-
-If you want a short example of a toy benchmark suite, see the sample file in this repo ([benchmark/benchmarks.jl](benchmark/benchmarks.jl)).
-
-If you want an extensive example of a benchmark suite being used in the real world, you can look at the source code of [BaseBenchmarks.jl](https://github.com/JuliaCI/BaseBenchmarks.jl/tree/nanosoldier).
-
-If you're benchmarking on Linux, I wrote up a series of [tips and tricks](https://github.com/JuliaCI/BenchmarkTools.jl/blob/master/doc/linuxtips.md) to help eliminate noise during performance tests.
 
 ## Why does this package exist?
 


### PR DESCRIPTION
The vast majority of users probably just want `@btime`, so I think it is useful to include a "quick start" section in the manual that just gives a couple of examples (including interpolation).