### PR TITLE
Recursively deserialize nested BenchmarkGroups

### DIFF
--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -33,6 +33,13 @@ function recover(x::Vector)
         else
             convert(ft, fields[fn])
         end
+        if T == BenchmarkGroup && xs[i] isa Dict
+            for (k, v) in xs[i]
+                if v isa Vector && length(v) == 2 && v[1] isa String
+                    xs[i][k] = recover(v)
+                end
+            end
+        end
     end
     T(xs...)
 end

--- a/test/SerializationTests.jl
+++ b/test/SerializationTests.jl
@@ -35,6 +35,21 @@ end
         @test eq(results[1], b)
         @test eq(results[2], bb)
     end
+
+    # Nested BenchmarkGroups
+    withtempdir() do
+        tmp = joinpath(pwd(), "tmp.json")
+
+        g = BenchmarkGroup()
+        g["a"] = BenchmarkGroup()
+        g["b"] = BenchmarkGroup()
+        g["c"] = BenchmarkGroup()
+        BenchmarkTools.save(tmp, g)
+
+        results = BenchmarkTools.load(tmp)[1]
+        @test results isa BenchmarkGroup
+        @test all(v->v isa BenchmarkGroup, values(results.data))
+    end
 end
 
 @testset "Deprecated behaviors" begin


### PR DESCRIPTION
Should fix the issue noted in BaseBenchmarks while updating to this version of BenchmarkTools: https://github.com/JuliaCI/BaseBenchmarks.jl/pull/132