### PR TITLE
[RFC/WIP] Tools for measuring cycles and cpu_times and tricking out LLVM

### DIFF
--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -49,6 +49,14 @@ export BenchmarkGroup,
        addgroup!,
        leaves
 
+##########################
+# Low-level benchmarking #
+##########################
+
+include("lowlevel.jl")
+export clobber,
+       escape
+
 ######################
 # Execution Strategy #
 ######################

--- a/src/lowlevel.jl
+++ b/src/lowlevel.jl
@@ -1,0 +1,57 @@
+##########################
+# Low-level benchmarking #
+##########################
+import Base: llvmcall
+
+"""
+    clobber()
+
+Force the compiler to flush pending writes to global memory.
+Acts as an effective read/write barrier.
+"""
+@inline function clobber()
+    llvmcall("""
+        call void asm sideeffect "", "~{memory}"()
+        ret void
+    """, Void, Tuple{})
+end
+
+"""
+    _llvmname(type::Type)
+
+Produce the string name of the llvm equivalent of our Julia code.
+Oh my. The preferable way would be to use LLVM.jl to do this for us.
+"""
+function _llvmname(typ::Type)
+    isboxed_ref = Ref{Bool}()
+    llvmtyp = ccall(:julia_type_to_llvm, Ptr{Void},
+                    (Any, Ptr{Bool}), typ, isboxed_ref)
+    name = unsafe_string(
+        ccall(:LLVMPrintTypeToString, Cstring, (Ptr{Void},), llvmtyp))
+    if isboxed_ref[]
+        return name * "*"
+    else
+        return name
+    end
+end
+
+"""
+    escape(val)
+
+The `escape` function can be used to prevent a value or
+expression from being optimized away by the compiler. This function is
+intended to add little to no overhead.
+See: https://youtu.be/nXaxk27zwlk?t=2441
+"""
+@generated function escape(val::T) where T
+    # We need to get the darn LLVMName to be able to issue a
+    # fake call. There is probably a better way to do this.
+    name = _llvmname(T)
+    ir = """
+        call void asm sideeffect "", "X,~{memory}"($name %0)
+        ret void
+    """
+    quote 
+        llvmcall($ir, Void, Tuple{T}, val)
+    end
+end

--- a/src/lowlevel.jl
+++ b/src/lowlevel.jl
@@ -116,3 +116,39 @@ macro elapsed_cyc(ex)
         cyc_convert(c1)-cyc_convert(c0)
     end
 end
+
+##########
+# Timers #
+##########
+struct TimeSpec
+    tv_sec  :: UInt64 # time_t
+    tv_nsec :: UInt64
+end
+
+const CLOCK_PROCESS_CPUTIME_ID = Cint(2)
+const CLOCK_THREAD_CPUTIME_ID  = Cint(3)
+
+@inline function clock_gettime(cid)
+    ts = Ref{TimeSpec}()
+    ccall(:clock_gettime, Cint, (Cint, Ref{TimeSpec}), cid, ts)
+    return ts[].tv_nsec
+end
+
+"""
+    getProcessTime()
+
+Per-process  CPU-time  clock  (measures CPU time consumed by all
+threads in the process).
+"""
+@inline function getProcessTime()
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID)
+end
+
+"""
+    getThreadTime()
+
+Thread-specific CPU-time clock.
+"""
+@inline function getThreadTime()
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID)
+end

--- a/src/lowlevel.jl
+++ b/src/lowlevel.jl
@@ -28,11 +28,7 @@ function _llvmname(typ::Type)
                     (Any, Ptr{Bool}), typ, isboxed_ref)
     name = unsafe_string(
         ccall(:LLVMPrintTypeToString, Cstring, (Ptr{Void},), llvmtyp))
-    if isboxed_ref[]
-        return name * "*"
-    else
-        return name
-    end
+    return (isboxed_ref[], name)
 end
 
 """
@@ -44,14 +40,25 @@ intended to add little to no overhead.
 See: https://youtu.be/nXaxk27zwlk?t=2441
 """
 @generated function escape(val::T) where T
-    # We need to get the darn LLVMName to be able to issue a
-    # fake call. There is probably a better way to do this.
-    name = _llvmname(T)
-    ir = """
-        call void asm sideeffect "", "X,~{memory}"($name %0)
-        ret void
-    """
-    quote 
-        llvmcall($ir, Void, Tuple{T}, val)
+    # If the value is `nothing` then a memory clobber
+    # should have the same effect.
+    if T == Void
+        return :(clobber())
+    end
+    # We need to get the string representation of the LLVM type to be able to issue a
+    # fake call.
+    isboxed, name = _llvmname(T)
+    if isboxed
+        # name will be `jl_value_t*` which we can't use since string based llvmcall can't handle named structs...
+        # Ideally we would issue a `bitcast jl_value_t* %0 to i8*`
+        Base.warn_once("Trying to escape a boxed value. Don't know how to handle that.")
+    else
+        ir = """
+            call void asm sideeffect "", "X,~{memory}"($name %0)
+            ret void
+        """
+        quote
+            llvmcall($ir, Void, Tuple{T}, val)
+        end
     end
 end

--- a/src/lowlevel.jl
+++ b/src/lowlevel.jl
@@ -124,6 +124,7 @@ struct TimeSpec
     tv_sec  :: UInt64 # time_t
     tv_nsec :: UInt64
 end
+maketime(ts) = ts.tv_sec + ts.tv_nsec * 1e-9
 
 const CLOCK_PROCESS_CPUTIME_ID = Cint(2)
 const CLOCK_THREAD_CPUTIME_ID  = Cint(3)
@@ -131,7 +132,7 @@ const CLOCK_THREAD_CPUTIME_ID  = Cint(3)
 @inline function clock_gettime(cid)
     ts = Ref{TimeSpec}()
     ccall(:clock_gettime, Cint, (Cint, Ref{TimeSpec}), cid, ts)
-    return ts[].tv_nsec
+    return ts[]
 end
 
 """
@@ -141,7 +142,7 @@ Per-process  CPU-time  clock  (measures CPU time consumed by all
 threads in the process).
 """
 @inline function getProcessTime()
-    clock_gettime(CLOCK_PROCESS_CPUTIME_ID)
+    maketime(clock_gettime(CLOCK_PROCESS_CPUTIME_ID))
 end
 
 """
@@ -150,5 +151,5 @@ end
 Thread-specific CPU-time clock.
 """
 @inline function getThreadTime()
-    clock_gettime(CLOCK_THREAD_CPUTIME_ID)
+    maketime(clock_gettime(CLOCK_THREAD_CPUTIME_ID))
 end


### PR DESCRIPTION
I recently started exploring options for more precise and low-level benchmarking tools.
As it is this PR is *notready* to be included in `BenchmarkTools`, but should provide a starting point for discussions.

1. `clobber()` and `escape()` 
  Two methods to prevent certain compiler optimisations on the LLVM level. (see https://youtu.be/nXaxk27zwlk?t=2441)
  `clobber()` is a memory barrier that forces the compiler to flush all writes to memory and `escape` is an method to prevent
   LLVM from optimising a value away since we are faking a store of it. `escape()` is not quite done since it can't handel boxed values
   and it would be easier to write if we could depend on LLVM.jl

2. `bench_start()` and `bench_end()` 
  Inspired by https://github.com/dterei/gotsc and https://www.intel.com/content/www/us/en/embedded/training/ia-32-ia-64-benchmark-code-execution-paper.html
  Since CPUs can do speculative execution reordering and a bunch of other shenanigans this is a very careful series of instructions that tries to prevent as much of that 
  as possible and thus should give a as precise as possible estimate of the number of cycles it takes for a block of code to run. These instructions are not completely noise free
  since we still are running in user-space and the current implementation is *x86_64* only (and requires a series of processor features). It is also tricky to convert cycles
  to time spend. If we use this method it should be opt-in and we need to method variance and overhead.

3. `getProcessTime()` and `getThreadTime()`
   I got curious and looked into what [google/benchmark](https://github.com/google/benchmark) is using for time measurement and it turns out they actual measure two things.
   run time and cpu time, where the latter is the time that a process is actually spend being run. The current implementation is Linux only but can get extended to to all platforms we
   care about. For runtime measurement they uses http://en.cppreference.com/w/cpp/chrono/high_resolution_clock. Currently we are using `uv_hrtime` from `libuv`.
   Both `uv_hrtime` and the c++ timer will under Unix fall back to `clock_gettime(CLOCK_MONOTONIC, ...)` similar to my implementation of `getProcessTime`.

What should we do?
I think taking a lead from [google/benchmark](https://github.com/google/benchmark)  and also measuring CPU time vs just runtime would be a first good actionable item. I am much 
less sure about what to do with `1.` and `2.` and if they are useful for `BenchmarkTools.jl`, that needs further evaluation and for that I currently don't have time.
