### PR TITLE
allow to save and load from ::IO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 benchmark/params.jld
+test/x.json


### PR DESCRIPTION
It is sometimes useful to be able to save and load data without having to roundtrip to a file.

Also, adds `test/x.json` to `.gitignore` because otherwise the gitrepo gets dirty after testing (and will never be upgraded by Pkg.update).