### PR TITLE
Assign directly deep into BenchmarkGroup

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -827,6 +827,27 @@ BenchmarkTools.BenchmarkGroup:
 		  :b => "hello"
 ```
 
+Assigning into a `BenchmarkGroup` with a `Vector` creates sub-groups as necessary:
+
+```julia
+julia>  g[[2, "a", :b]] = "hello again"
+"hello again"
+
+julia>  showall(g)
+2-element BenchmarkTools.BenchmarkGroup:
+  tags: []
+  2 => 1-element BenchmarkTools.BenchmarkGroup:
+          tags: []
+          "a" => 1-element BenchmarkTools.BenchmarkGroup:
+                  tags: []
+                  :b => "hello again"
+  1 => 1-element BenchmarkTools.BenchmarkGroup:
+          tags: []
+          "a" => 1-element BenchmarkTools.BenchmarkGroup:
+                  tags: []
+                  :b => "hello"
+```
+
 You can use the `leaves` function to construct an iterator over a group's leaf index/value pairs:
 
 ```julia

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -140,6 +140,9 @@ function Base.setindex!(group::BenchmarkGroup, x, keys::Vector)
         group[k] = x
         return x
     else
+        if !haskey(group, k)
+            group[k] = BenchmarkGroup()
+        end
         return setindex!(group[k], x, keys[2:end])
     end
 end

--- a/test/GroupsTests.jl
+++ b/test/GroupsTests.jl
@@ -235,15 +235,15 @@ gx["e"] = BenchmarkGroup([], "1" => g["e"]["1"][x["a"]], "3" => g["e"]["3"][x["c
 
 @test g[x] == gx
 
-# deep index assignment in BenchmarkGroup #
-#-----------------------------------------#
+# indexing by Vector #
+#--------------------#
 
 g1 = BenchmarkGroup(1 => BenchmarkGroup("a" => BenchmarkGroup()))
 g1[[1, "a", :b]] = "hello"
 @test g1[[1, "a", :b]] == "hello"
 
 g2 = BenchmarkGroup()
-g2[[1, "a", :b]] = "hello"
+g2[[1, "a", :b]] = "hello"  # should create higher levels on the fly
 @test g2[[1, "a", :b]] == "hello"
 
 @test g1 == g2

--- a/test/GroupsTests.jl
+++ b/test/GroupsTests.jl
@@ -235,4 +235,18 @@ gx["e"] = BenchmarkGroup([], "1" => g["e"]["1"][x["a"]], "3" => g["e"]["3"][x["c
 
 @test g[x] == gx
 
+# deep index assignment in BenchmarkGroup #
+#-----------------------------------------#
+
+g1 = BenchmarkGroup(1 => BenchmarkGroup("a" => BenchmarkGroup()))
+g1[[1, "a", :b]] = "hello"
+@test g1[[1, "a", :b]] == "hello"
+
+g2 = BenchmarkGroup()
+g2[[1, "a", :b]] = "hello"
+@test g2[[1, "a", :b]] == "hello"
+
+@test g1 == g2
+
+
 # end # module


### PR DESCRIPTION
This allows to assign directly deep into a BenchmarkGroup with a Vector
key, creating all intermediate levels as necessary:

    julia>  using BenchmarkTools
    julia>  g = BenchmarkGroup()
    julia>  g[[1, "a", :b]] = "hello"
    "hello"

Closes #101