### PR TITLE
Julia0.7 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.7
 Compat 0.62.0
 JSON

--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -5,6 +5,7 @@ module BenchmarkTools
 using Compat
 using JSON
 using Base.Iterators
+using Statistics
 
 using Compat.Printf
 

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -76,8 +76,8 @@ Base.filter(f, group::BenchmarkGroup) = filter!(f, copy(group))
 
 Base.minimum(group::BenchmarkGroup) = mapvals(minimum, group)
 Base.maximum(group::BenchmarkGroup) = mapvals(maximum, group)
-Base.mean(group::BenchmarkGroup) = mapvals(mean, group)
-Base.median(group::BenchmarkGroup) = mapvals(median, group)
+Statistics.mean(group::BenchmarkGroup) = mapvals(mean, group)
+Statistics.median(group::BenchmarkGroup) = mapvals(median, group)
 Base.min(groups::BenchmarkGroup...) = mapvals(min, groups...)
 Base.max(groups::BenchmarkGroup...) = mapvals(max, groups...)
 

--- a/src/trials.jl
+++ b/src/trials.jl
@@ -118,8 +118,8 @@ function Base.maximum(trial::Trial)
     return TrialEstimate(trial, trial.times[i], trial.gctimes[i])
 end
 
-Base.median(trial::Trial) = TrialEstimate(trial, median(trial.times), median(trial.gctimes))
-Base.mean(trial::Trial) = TrialEstimate(trial, mean(trial.times), mean(trial.gctimes))
+Statistics.median(trial::Trial) = TrialEstimate(trial, median(trial.times), median(trial.gctimes))
+Statistics.mean(trial::Trial) = TrialEstimate(trial, mean(trial.times), mean(trial.gctimes))
 
 Base.isless(a::TrialEstimate, b::TrialEstimate) = isless(time(a), time(b))
 

--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -3,8 +3,7 @@ module ExecutionTests
 using BenchmarkTools
 using Compat
 using Compat.Test
-
-using Compat.IterativeEigensolvers
+using Pkg
 
 seteq(a, b) = length(a) == length(b) == length(intersect(a, b))
 
@@ -26,7 +25,9 @@ for s in sizes
 end
 
 groups["special"]["macro"] = @benchmarkable @test(1 == 1)
-groups["special"]["kwargs"] = @benchmarkable svds(rand(2, 2), nsv = 1)
+if "Arpack" in keys(Pkg.installed())
+    groups["special"]["kwargs"] = @benchmarkable svds(rand(2, 2), nsv = 1)
+end
 groups["special"]["nothing"] = @benchmarkable nothing
 groups["special"]["block"] = @benchmarkable begin rand(3) end
 groups["special"]["comprehension"] = @benchmarkable [s^2 for s in sizes]

--- a/test/GroupsTests.jl
+++ b/test/GroupsTests.jl
@@ -4,6 +4,7 @@ using BenchmarkTools
 using BenchmarkTools: TrialEstimate, Parameters
 using Compat
 using Compat.Test
+using Statistics
 
 seteq(a, b) = length(a) == length(b) == length(intersect(a, b))
 

--- a/test/TrialsTests.jl
+++ b/test/TrialsTests.jl
@@ -3,6 +3,7 @@ module TrialsTests
 using BenchmarkTools
 using Compat
 using Compat.Test
+using Statistics
 
 #########
 # Trial #


### PR DESCRIPTION
Small PR, I just fixed depwarns on use of `mean` and `median` by using `Statistics` where appropriate. Two other changes:

- Newer versions of Compat remove the IterativeEigensolvers module. I didn't know what you'd want to do with this test; I made it conditional on Arpack.jl being installed.
- I haven't done any package development of my own, so I don't know if my updates to the CI script and REQUIRE are quite correct.