### PR TITLE
prevent a few variables from becoming global

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -209,7 +209,7 @@ macro benchmark(args...)
     _, params = prunekwargs(args...)
     tmp = gensym()
     return esc(quote
-        $tmp = $BenchmarkTools.@benchmarkable $(args...)
+        local $tmp = $BenchmarkTools.@benchmarkable $(args...)
         $BenchmarkTools.warmup($tmp)
         $(hasevals(params) ? :() : :($BenchmarkTools.tune!($tmp)))
         $BenchmarkTools.run($tmp)
@@ -358,7 +358,6 @@ parameters as `@benchmark`.  The returned time
 is the *minimum* elapsed time measured during the benchmark.
 """
 macro belapsed(args...)
-    b = Expr(:macrocall, Symbol("@benchmark"), map(esc, args)...)
     return esc(quote
         $BenchmarkTools.time($BenchmarkTools.minimum($BenchmarkTools.@benchmark $(args...)))/1e9
     end)
@@ -383,12 +382,12 @@ macro btime(args...)
     trialmin, trialallocs = gensym(), gensym()
     tune_phase = hasevals(params) ? :() : :($BenchmarkTools.tune!($bench))
     return esc(quote
-        $bench = $BenchmarkTools.@benchmarkable $(args...)
+        local $bench = $BenchmarkTools.@benchmarkable $(args...)
         $BenchmarkTools.warmup($bench)
         $tune_phase
-        $trial, $result = $BenchmarkTools.run_result($bench)
-        $trialmin = $BenchmarkTools.minimum($trial)
-        $trialallocs = $BenchmarkTools.allocs($trialmin)
+        local $trial, $result = $BenchmarkTools.run_result($bench)
+        local $trialmin = $BenchmarkTools.minimum($trial)
+        local $trialallocs = $BenchmarkTools.allocs($trialmin)
         println("  ",
                 $BenchmarkTools.prettytime($BenchmarkTools.time($trialmin)),
                 " (", $trialallocs , " allocation",


### PR DESCRIPTION
Was looking into https://discourse.julialang.org/t/when-does-the-garbage-collector-runs/15142 but don't think this fixes it. Anyway, seems like an improvement.

After running `@btime` once:

Before:

```
julia> names(Main; all=true)
18-element Array{Symbol,1}:
 Symbol("###core#367")
 Symbol("###sample#368")
 Symbol("##1#2")
 Symbol("##360")
 Symbol("##361")
 Symbol("##362")
 Symbol("##363")
 Symbol("##364")
 Symbol("##_run#3")
 Symbol("##core#367")
 Symbol("##sample#368")
 Symbol("#_run#3")
...
```

After:

```
julia> names(Main; all=true)
 Symbol("###core#367")
 Symbol("###sample#368")
 Symbol("##1#2")
 Symbol("##_run#3")
 Symbol("##core#367")
 Symbol("##sample#368")
 Symbol("#_run#3")
...
```