### PR TITLE
Improve/fix show methods

### DIFF
--- a/src/groups.jl
+++ b/src/groups.jl
@@ -258,13 +258,7 @@ function Base.show(io::IO, group::BenchmarkGroup)
     for (k, v) in group
         println(io)
         print(io, pad, "  ", repr(k), " => ")
-        if get(io, :verbose, false) && isa(v, BenchmarkGroup)
-            show(IOContext(io, :pad => "\t"*pad), v)
-        elseif get(io, :compact, true)
-            summary(IOContext(io, :pad => "\t"*pad), v)
-        else
-            show(IOContext(io, :pad => "\t"*pad), v)
-        end
+        show(IOContext(io, :pad => "\t"*pad), v)
         count > get(io, :limit, 10) && (println(io); print(io, pad, "  ⋮"); break)
         count += 1
     end

--- a/src/trials.jl
+++ b/src/trials.jl
@@ -295,7 +295,7 @@ Base.summary(io::IO, t::TrialJudgement) = withtypename(io, t) do
 end
 
 _show(io, t) =
-    if !(get(io, :verbose, false)) && get(io, :compact, true)
+    if get(io, :compact, true)
         summary(io, t)
     else
         show(io, MIME"text/plain"(), t)

--- a/src/trials.jl
+++ b/src/trials.jl
@@ -225,6 +225,17 @@ isimprovement(t::TrialJudgement) = time(t) == :improvement || memory(t) == :impr
 isregression(t::TrialJudgement) = time(t) == :regression || memory(t) == :regression
 isinvariant(t::TrialJudgement) = time(t) == :invariant && memory(t) == :invariant
 
+const colormap = (
+    regression = :red,
+    improvement = :green,
+    invariant = :normal,
+)
+
+printtimejudge(io, t::TrialJudgement) =
+    printstyled(io, time(t); color=colormap[time(t)])
+printmemoryjudge(io, t::TrialJudgement) =
+    printstyled(io, memory(t); color=colormap[memory(t)])
+
 ###################
 # Pretty Printing #
 ###################
@@ -262,12 +273,40 @@ function prettymemory(b)
     return string(@sprintf("%.2f", value), " ", units)
 end
 
-Base.summary(io::IO, t::Trial) = print(io, "Trial(", prettytime(time(t)), ")")
-Base.summary(io::IO, t::TrialEstimate) = print(io, "TrialEstimate(", prettytime(time(t)), ")")
-Base.summary(io::IO, t::TrialRatio) = print(io, "TrialRatio(", prettypercent(time(t)), ")")
-Base.summary(io::IO, t::TrialJudgement) = print(io, "TrialJudgement(", prettydiff(time(ratio(t))), " => ", time(t), ")")
+function withtypename(f, io, t)
+    needtype = get(io, :typeinfo, Nothing) !== typeof(t)
+    if needtype
+        print(io, nameof(typeof(t)), '(')
+    end
+    f()
+    if needtype
+        print(io, ')')
+    end
+end
 
-function Base.show(io::IO, t::Trial)
+_summary(io, t, args...) = withtypename(() -> print(io, args...), io, t)
+
+Base.summary(io::IO, t::Trial) = _summary(io, t, prettytime(time(t)))
+Base.summary(io::IO, t::TrialEstimate) = _summary(io, t, prettytime(time(t)))
+Base.summary(io::IO, t::TrialRatio) = _summary(io, t, prettypercent(time(t)))
+Base.summary(io::IO, t::TrialJudgement) = withtypename(io, t) do
+    print(io, prettydiff(time(ratio(t))), " => ")
+    printtimejudge(io, t)
+end
+
+_show(io, t) =
+    if !(get(io, :verbose, false)) && get(io, :compact, true)
+        summary(io, t)
+    else
+        show(io, MIME"text/plain"(), t)
+    end
+
+Base.show(io::IO, t::Trial) = _show(io, t)
+Base.show(io::IO, t::TrialEstimate) = _show(io, t)
+Base.show(io::IO, t::TrialRatio) = _show(io, t)
+Base.show(io::IO, t::TrialJudgement) = _show(io, t)
+
+function Base.show(io::IO, ::MIME"text/plain", t::Trial)
     if length(t) > 0
         min = minimum(t)
         max = maximum(t)
@@ -301,7 +340,7 @@ function Base.show(io::IO, t::Trial)
     print(io,   pad, "  evals/sample:     ", t.params.evals)
 end
 
-function Base.show(io::IO, t::TrialEstimate)
+function Base.show(io::IO, ::MIME"text/plain", t::TrialEstimate)
     println(io, "BenchmarkTools.TrialEstimate: ")
     pad = get(io, :pad, "")
     println(io, pad, "  time:             ", prettytime(time(t)))
@@ -310,7 +349,7 @@ function Base.show(io::IO, t::TrialEstimate)
     print(io,   pad, "  allocs:           ", allocs(t))
 end
 
-function Base.show(io::IO, t::TrialRatio)
+function Base.show(io::IO, ::MIME"text/plain", t::TrialRatio)
     println(io, "BenchmarkTools.TrialRatio: ")
     pad = get(io, :pad, "")
     println(io, pad, "  time:             ", time(t))
@@ -319,9 +358,13 @@ function Base.show(io::IO, t::TrialRatio)
     print(io,   pad, "  allocs:           ", allocs(t))
 end
 
-function Base.show(io::IO, t::TrialJudgement)
+function Base.show(io::IO, ::MIME"text/plain", t::TrialJudgement)
     println(io, "BenchmarkTools.TrialJudgement: ")
     pad = get(io, :pad, "")
-    println(io, pad, "  time:   ", prettydiff(time(ratio(t))), " => ", time(t), " (", prettypercent(params(t).time_tolerance), " tolerance)")
-    print(io,   pad, "  memory: ", prettydiff(memory(ratio(t))), " => ", memory(t), " (", prettypercent(params(t).memory_tolerance), " tolerance)")
+    print(io, pad, "  time:   ", prettydiff(time(ratio(t))), " => ")
+    printtimejudge(io, t)
+    println(io, " (", prettypercent(params(t).time_tolerance), " tolerance)")
+    print(io,   pad, "  memory: ", prettydiff(memory(ratio(t))), " => ")
+    printmemoryjudge(io, t)
+    println(io, " (", prettypercent(params(t).memory_tolerance), " tolerance)")
 end

--- a/test/TrialsTests.jl
+++ b/test/TrialsTests.jl
@@ -169,4 +169,25 @@ tj_r_2 = judge(tr; time_tolerance = 2.0, memory_tolerance = 2.0)
 @test BenchmarkTools.prettymemory(1073741823) == "1024.00 MiB"
 @test BenchmarkTools.prettymemory(1073741824) == "1.00 GiB"
 
+@test sprint(show, "text/plain", ta) == sprint(show, ta; context=:compact => false) == """
+BenchmarkTools.TrialEstimate: 
+  time:             0.490 ns
+  gctime:           0.000 ns (0.00%)
+  memory:           2 bytes
+  allocs:           1"""
+
+@test sprint(show, ta) == "TrialEstimate(0.490 ns)"
+@test sprint(
+    show, ta;
+    context = IOContext(
+        devnull, :compact => true, :typeinfo => BenchmarkTools.TrialEstimate)
+) == "0.490 ns"
+
+@test sprint(show, [ta, tb]) == "BenchmarkTools.TrialEstimate[0.490 ns, 1.000 ns]"
+
+@test sprint(show, "text/plain", [ta, tb]) == """
+2-element Array{BenchmarkTools.TrialEstimate,1}:
+ 0.490 ns
+ 1.000 ns"""
+
 end # module


### PR DESCRIPTION
Previously the logic for switching compact or verbose form of various
benchmark result objects are in `show(io::IO, group::BenchmarkGroup)`.
A more natural place would be `show(io::IO, t::Trial)` etc. as it let
code outside BenchmarkTools to switch the compactness using the
standard `IOContext` interface.  For example, with this patch `Trial`s
in `Vector` are shown in the compact form automatically.

This patch also adds:
* Colored output for the words `improvement` and `regression`.
* `:typeinfo` IO context support

As a result, you can get a nice summary view by putting benchmark objects in a `DataFrame`:

![image](https://user-images.githubusercontent.com/29282/49688897-df83da00-facd-11e8-995e-a92bcdda60e4.png)