### PR TITLE
Add progress logging based on ProgressLogging.jl spec

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,10 @@ version = "0.4.3"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 julia = "≥ 0.7.0"

--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -3,7 +3,9 @@ module BenchmarkTools
 using JSON
 using Base.Iterators
 
+using Logging: @logmsg, LogLevel
 using Statistics
+using UUIDs: uuid4
 using Printf
 
 

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -100,12 +100,7 @@ Base.run(group::BenchmarkGroup, args...; verbose::Bool = false, pad = "", kwargs
         gcscrub() # run GC before running group, even if individual benchmarks don't manually GC
         i = 1
         for id in keys(group)
-            progressid === nothing || @logmsg(
-                ProgressLevel,
-                "Benchmarking",
-                progress = ndone / nleaves,
-                _id = progressid
-            )
+            @logmsg(ProgressLevel, "Benchmarking", progress = ndone / nleaves, _id = progressid)
             verbose &&
                 println(pad, "($(i)/$(length(group))) benchmarking ", repr(id), "...")
             took_seconds = @elapsed begin
@@ -190,12 +185,7 @@ tune!(group::BenchmarkGroup; verbose::Bool = false, pad = "", kwargs...) =
         gcscrub() # run GC before running group, even if individual benchmarks don't manually GC
         i = 1
         for id in keys(group)
-            progressid === nothing || @logmsg(
-                ProgressLevel,
-                "Tuning",
-                progress = ndone / nleaves,
-                _id = progressid
-            )
+            @logmsg(ProgressLevel, "Tuning", progress = ndone / nleaves, _id = progressid)
             verbose && println(pad, "($(i)/$(length(group))) tuning ", repr(id), "...")
             took_seconds = @elapsed tune!(
                 group[id];


### PR DESCRIPTION
With this patch, BenchmarkTools now emits progress logging records as [specified](https://junolab.org/ProgressLogging.jl/dev/#ProgressLogging.progress-Tuple{Any}) by [ProgressLogging.jl](https://github.com/JunoLab/ProgressLogging.jl).  You can observe progress as progress bars if you set up a progress monitor such as Juno and [TerminalLoggers.jl](https://github.com/c42f/TerminalLoggers.jl)

Note that this patch does _not_ add ProgressLogging.jl or any non-stdlib packages as dependencies.

Example:

![Peek 2020-01-25 22-43](https://user-images.githubusercontent.com/29282/73131669-4ad78680-3fc4-11ea-8cdc-e2581494eedf.gif)

```julia
using Logging
using TerminalLoggers
using BenchmarkTools

with_logger(TerminalLogger()) do
    suite = BenchmarkGroup()
    for n in [100, 200, 400]
        suite[n] = s1 = BenchmarkGroup()
        for T in [Int, Float64, ComplexF64]
            s1[T] = @benchmarkable rand($T, $n)
        end
    end
    tune!(suite, verbose=true)
    run(suite, verbose=true)
end
```
