### PR TITLE
Fix how IOContext :limit is handled

### DIFF
--- a/src/groups.jl
+++ b/src/groups.jl
@@ -267,6 +267,21 @@ tagrepr(tags) = string("[", join(map(repr, tags), ", "), "]")
 Base.summary(io::IO, group::BenchmarkGroup) = print(io, "$(length(group))-element BenchmarkGroup($(tagrepr(group.tags)))")
 
 function Base.show(io::IO, group::BenchmarkGroup)
+    limit = get(io, :limit, true)
+    if !(limit isa Bool)
+        msg = (
+            "`show(IOContext(io, :limit => number), group::BenchmarkGroup)` is" *
+            " deprecated. Please use `IOContext(io, :boundto => number)` to" *
+            " bound the number of elements to be shown."
+        )
+        Base.depwarn(msg, :show)
+        nbound = get(io, :boundto, limit)
+    elseif limit === false
+        nbound = Inf
+    else
+        nbound = get(io, :boundto, 10)
+    end
+
     println(io, "$(length(group))-element BenchmarkTools.BenchmarkGroup:")
     pad = get(io, :pad, "")
     print(io, pad, "  tags: ", tagrepr(group.tags))
@@ -275,7 +290,7 @@ function Base.show(io::IO, group::BenchmarkGroup)
         println(io)
         print(io, pad, "  ", repr(k), " => ")
         show(IOContext(io, :pad => "\t"*pad), v)
-        count > get(io, :limit, 10) && (println(io); print(io, pad, "  ⋮"); break)
+        count > nbound && (println(io); print(io, pad, "  ⋮"); break)
         count += 1
     end
 end

--- a/test/GroupsTests.jl
+++ b/test/GroupsTests.jl
@@ -277,5 +277,37 @@ g2[[1, "a", :b]] = "hello"  # should create higher levels on the fly
 
 @test g1 == g2
 
+# pretty printing #
+#-----------------#
+
+g1 = BenchmarkGroup(["1", "2"])
+g1["a"] = t1a
+g1["b"] = t1b
+g1["c"] = tc
+
+@test sprint(show, g1) == """
+3-element BenchmarkTools.BenchmarkGroup:
+  tags: ["1", "2"]
+  "c" => TrialEstimate(1.000 ns)
+  "b" => TrialEstimate(4.123 μs)
+  "a" => TrialEstimate(32.000 ns)"""
+@test sprint(show, g1; context = :boundto => 1) == """
+3-element BenchmarkTools.BenchmarkGroup:
+  tags: ["1", "2"]
+  "c" => TrialEstimate(1.000 ns)
+  "b" => TrialEstimate(4.123 μs)
+  ⋮"""
+@test sprint(show, g1; context = :limit => false) == """
+3-element BenchmarkTools.BenchmarkGroup:
+  tags: ["1", "2"]
+  "c" => TrialEstimate(1.000 ns)
+  "b" => TrialEstimate(4.123 μs)
+  "a" => TrialEstimate(32.000 ns)"""
+@test @test_deprecated(sprint(show, g1; context = :limit => 1)) == """
+3-element BenchmarkTools.BenchmarkGroup:
+  tags: ["1", "2"]
+  "c" => TrialEstimate(1.000 ns)
+  "b" => TrialEstimate(4.123 μs)
+  ⋮"""
 
 # end # module


### PR DESCRIPTION
The docstring of `IOContext` specifies that `:limit` contains a `Bool`
for toggling if the output should be truncated.  The previous usage of
`:limit` in BenchmarkTools.jl treats it as an upper bound of the
numebr of elements to be shown; it is incompatible with the common
usage.  This PR fixes it by introducing a new (non-standard) context
`:boundto` that can be used to specify the upper bound of the number
of elements to be printed for each level.  The old usage of `:limit`
is still supported with deprecation if it is not a `Bool`.

With this patch, you can use [`DisplayAs.Unlimited`](https://tkf.github.io/DisplayAs.jl/dev/#DisplayAs.Unlimited) to print details:

```julia
julia> g1
3-element BenchmarkTools.BenchmarkGroup:
  tags: ["1", "2"]
  "c" => TrialEstimate(1.000 ns)
  "b" => TrialEstimate(4.123 μs)
  "a" => TrialEstimate(32.000 ns)

julia> DisplayAs.Unlimited(g1)
3-element BenchmarkTools.BenchmarkGroup:
  tags: ["1", "2"]
  "c" => BenchmarkTools.TrialEstimate:
          time:             1.000 ns
          gctime:           1.000 ns (100.00%)
          memory:           1 bytes
          allocs:           1
  "b" => BenchmarkTools.TrialEstimate:
          time:             4.123 μs
          gctime:           123.000 ns (2.98%)
          memory:           43 bytes
          allocs:           9
  "a" => BenchmarkTools.TrialEstimate:
          time:             32.000 ns
          gctime:           1.000 ns (3.13%)
          memory:           2 bytes
          allocs:           3
```
