### PR TITLE
Add ballocated macro

### DIFF
--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -60,6 +60,7 @@ include("execution.jl")
 
 export tune!,
        warmup,
+       @ballocated,
        @benchmark,
        @benchmarkable,
        @belapsed,

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -375,7 +375,7 @@ this returns the number of bytes allocated when executing
 a given expression.   It uses the `@benchmark`
 macro, however, and accepts all of the same additional
 parameters as `@benchmark`.  The returned allocations
-is for the trial with the *minimum* elapsed time measured
+correspond to the trial with the *minimum* elapsed time measured
 during the benchmark.
 """
 macro ballocated(args...)

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -348,7 +348,7 @@ end
 ######################
 
 # These macros provide drop-in replacements for the
-# Base.@time and Base.@elapsed macros, which use
+# Base.@time, Base.@elapsed macros and Base.@allocated, which use
 # @benchmark but yield only the minimum time.
 
 """
@@ -364,6 +364,23 @@ is the *minimum* elapsed time measured during the benchmark.
 macro belapsed(args...)
     return esc(quote
         $BenchmarkTools.time($BenchmarkTools.minimum($BenchmarkTools.@benchmark $(args...)))/1e9
+    end)
+end
+
+"""
+    @ballocated expression [other parameters...]
+
+Similar to the `@allocated` macro included with Julia,
+this returns the number of bytes allocated when executing
+a given expression.   It uses the `@benchmark`
+macro, however, and accepts all of the same additional
+parameters as `@benchmark`.  The returned allocations
+is for the trial with the *minimum* elapsed time measured
+during the benchmark.
+"""
+macro ballocated(args...)
+    return esc(quote
+        $BenchmarkTools.memory($BenchmarkTools.minimum($BenchmarkTools.@benchmark $(args...)))
     end)
 end
 

--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -154,6 +154,10 @@ tune!(b)
 @test @belapsed(sin($(foo.x)), evals=3, samples=10, setup=(foo.x = 0)) < 1
 @test @belapsed(sin(0)) < 1
 
+@test @ballocated(sin($(foo.x)), evals=3, samples=10, setup=(foo.x = 0)) == 0
+@test @ballocated(sin(0)) == 0
+@test @ballocated(Ref(1)) == 2*sizeof(Int)  # 1 for the pointer, 1 for content
+
 let fname = tempname()
     try
         ret = open(fname, "w") do f


### PR DESCRIPTION
Matchs to the `@allocated` macro.
Which I used in a few tests,
but which in Julia 1.4+ now disagrees with allocations reported by `@btime`
(see https://github.com/invenia/NamedDims.jl/issues/89 caused by https://github.com/JuliaLang/julia/pull/33717)

So I want `@ballocated`: allocation sizes that I can trust.