### PR TITLE
make sure that nullfunc is not ellided

### DIFF
--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -72,7 +72,7 @@ end
 # RESOLUTION/OVERHEAD settings #
 ################################
 
-@noinline nullfunc() = nothing
+@noinline nullfunc() = Base.inferencebarrier(nothing)::Nothing
 
 @noinline function overhead_sample(evals)
     start_time = time_ns()


### PR DESCRIPTION
fixes #163

We don't use these functions by default to estimate the overhead,
but right now they give the answer of:

```
before = time_ns()
after = time_ns()
(after-before)/evals
```

Which is not a particular helpful estimate of the costs. With 
a inference barrier we have a for-loop and a call to a function.

We explicitly note in https://github.com/JuliaCI/BenchmarkTools.jl/blob/master/doc/manual.md#understanding-compiler-optimizations
that compiler optimizations like that have to be accounted for by the user

This is more accurate and seems more stable, but requires a large number
of iterations to converge, probably means we should revitalize #94.

```
julia> BenchmarkTools.overhead_sample(10000)
2.8025

julia> BenchmarkTools.overhead_sample(10000)
6.3016

julia> BenchmarkTools.overhead_sample(10000)
5.5982

julia> BenchmarkTools.overhead_sample(10000)
6.3029

julia> BenchmarkTools.overhead_sample(10000)
6.2975

julia> BenchmarkTools.overhead_sample(10000)
5.5966

julia> BenchmarkTools.overhead_sample(100000)
5.79436

julia> BenchmarkTools.overhead_sample(1000000)
5.312702

julia> BenchmarkTools.overhead_sample(10000000)
3.9741005

julia> BenchmarkTools.overhead_sample(100000000)
1.59801717

julia> BenchmarkTools.overhead_sample(1000000000)
1.385175517

julia> BenchmarkTools.overhead_sample(10000000000)
1.3278229344

julia> BenchmarkTools.overhead_sample(100000000000)
1.37250904273
```