### PR TITLE
[RFC] Display histogram when showing trial

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,10 +8,12 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
+JSON = "0.18, 0.19, 0.20, 0.21"
+UnicodePlots = "1.3"
 julia = "1"
-JSON  = "0.18, 0.19, 0.20, 0.21"
 
 [extras]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -7,6 +7,7 @@ using Logging: @logmsg, LogLevel
 using Statistics
 using UUIDs: uuid4
 using Printf
+import UnicodePlots
 
 
 const BENCHMARKTOOLS_VERSION = v"0.4.3"

--- a/src/trials.jl
+++ b/src/trials.jl
@@ -341,8 +341,11 @@ function Base.show(io::IO, ::MIME"text/plain", t::Trial)
     println(io, pad, "  mean time:        ", meanstr)
     println(io, pad, "  maximum time:     ", maxstr)
     println(io, pad, "  --------------")
+    print(  io, UnicodePlots.histogram(t.times, ylabel="ns"))
+    println(io, pad, "  --------------")
     println(io, pad, "  samples:          ", length(t))
-    print(io,   pad, "  evals/sample:     ", t.params.evals)
+    println(io, pad, "  evals/sample:     ", t.params.evals)
+    println(io, pad, "  --------------")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", t::TrialEstimate)


### PR DESCRIPTION
I think we can all agree that there is no good choice for summary statistics, given the fact that benchmarks are often multi-modal. `minimum` can be a decent choice if one is focused on performance tuning a specific implementation, but if a user is comparing two different implementations it can be often misleading.

This PR adds a histogram to the output when showing a Trial, hopefully encouraging the user to think more deeply about comparing two results.