### PR TITLE
Add plot capability

### DIFF
--- a/BenchmarkPlots/Project.toml
+++ b/BenchmarkPlots/Project.toml
@@ -1,0 +1,11 @@
+name = "BenchmarkPlots"
+uuid = "ab8c0f59-4072-4e0d-8f91-a91e1495eb26"
+version = "0.1.0"
+
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+
+[compat]
+BenchmarkTools = "<1"
+RecipesBase = "1"

--- a/BenchmarkPlots/Project.toml
+++ b/BenchmarkPlots/Project.toml
@@ -7,5 +7,5 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
-BenchmarkTools = "<1"
+BenchmarkTools = "1"
 RecipesBase = "1"

--- a/BenchmarkPlots/src/BenchmarkPlots.jl
+++ b/BenchmarkPlots/src/BenchmarkPlots.jl
@@ -1,0 +1,25 @@
+module BenchmarkPlots
+using RecipesBase
+using BenchmarkTools: Trial, BenchmarkGroup
+
+@recipe function f(::Type{Trial}, t::Trial)
+    seriestype --> :violin
+    legend --> false
+    yguide --> "t / ns"
+    xticks --> false
+    t.times
+end
+
+@recipe function f(g::BenchmarkGroup, keys=keys(g))
+    legend --> false
+    yguide --> "t / ns"
+    for k in keys
+        @series begin
+            label --> string(k)
+            xticks --> true
+            [string(k)], g[k]
+        end
+    end
+end
+
+end

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 julia = "1"
-JSON  = "0.18, 0.19, 0.20, 0.21"
+JSON = "0.18, 0.19, 0.20, 0.21"
 
 [extras]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -1,5 +1,4 @@
 # Manual
-
 BenchmarkTools was created to facilitate the following tasks:
 
 1. Organize collections of benchmarks into manageable benchmark suites
@@ -899,6 +898,32 @@ julia> loadparams!(suite, BenchmarkTools.load("params.json")[1], :evals, :sample
 ```
 
 Caching parameters in this manner leads to a far shorter turnaround time, and more importantly, much more consistent results.
+
+## Visualizing benchmark results
+The `Trial` object can be visualized using the `BenchmarkPlots` package:
+
+```julia
+using BenchmarkPlots, StatsPlots
+b = @benchmarkable lu(rand(10,10))
+t = run(b)
+
+plot(t)
+```
+
+This will show the timing results of the trial as a violin plot. You can use
+all the keyword arguments from `Plots.jl`, for instance `st=:box` or
+`yaxis=:log10`.
+
+If a `BenchmarkGroup` contains (only) `Trial`s, its results can be visualized
+simply by
+
+```julia
+using BenchmarkPlots, StatsPlots
+t = run(g)
+plot(t)
+```
+
+This will display each `Trial` as a violin plot.
 
 ## Miscellaneous tips and info
 


### PR DESCRIPTION
Adds a recipe to visualize the timings of a `Trial` or a `BenchmarkGroup` of `Trial`s using boxplots. Only pulls in `RecipesBase.jl` so should be fairly low impact (but I don't know how best to check that).

```julia
using BenchmarkTools, Plots, StatsPlots
...
result = run(benchmarkgroup)
plot(result, outliers=false)
```

![benchmarks](https://user-images.githubusercontent.com/6677110/109364965-4a2cb600-7890-11eb-81b3-7decf7ba1c6f.png)
