### PR TITLE
Fix documentation of @benchmark

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -321,7 +321,7 @@ function quasiquote!(ex::Expr, vars::Vector{Expr})
     return ex
 end
 
-raw"""
+@doc raw"""
     @benchmark <expr to benchmark> [setup=<setup expr>]
 
 Run benchmark on a given expression.


### PR DESCRIPTION
The docstring of `@benchmark` is a raw string literal, hence `@doc` is required.

This PR fixes #63.