### PR TITLE
Revise print bound for BenchmarkGroup

### DIFF
--- a/src/groups.jl
+++ b/src/groups.jl
@@ -297,8 +297,8 @@ function Base.show(io::IO, group::BenchmarkGroup)
         println(io)
         print(io, pad, "  ", repr(k), " => ")
         show(IOContext(io, :pad => "\t"*pad), v)
-        count > nbound && (println(io); print(io, pad, "  ⋮"); break)
         count += 1
+        count > nbound && (println(io); print(io, pad, "  ⋮"); break)
     end
 end
 

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -298,7 +298,7 @@ function Base.show(io::IO, group::BenchmarkGroup)
         print(io, pad, "  ", repr(k), " => ")
         show(IOContext(io, :pad => "\t"*pad), v)
         count += 1
-        count > nbound && (println(io); print(io, pad, "  ⋮"); break)
+        count > nbound && length(group) > count && (println(io); print(io, pad, "  ⋮"); break)
     end
 end
 


### PR DESCRIPTION
I found that the printing of a `BenchmarkGroup` is a bit inconsistent. There is a bound on the number of entries (the default bound is `10`). Assume there are `n` entries and the bound is `b`. If `n > b`, then it always prints `b + 1` entries followed by vertical dots in a new line at the end.
1. I expect that it should print `b` entries instead. I changed this in the first commit.
2. In the special case `n == b + 1`, one could print that last element instead of vertical dots; that of course contradicts the bound, so it may again be unexpected. I added that suggestion in the second commit but I am happy to drop it again.

Below is an example.

```julia
julia> using BenchmarkTools
julia> suite = BenchmarkGroup();
julia> test() = sleep(0.1);
julia> for i in 1:11
    suite[i] = @benchmarkable test()
end
julia> results = run(suite);

julia> results
```

`master` prints eleven entries followed by vertical dots:

```julia
11-element BenchmarkTools.BenchmarkGroup:
  tags: []
  5 => Trial(100.185 ms)
  8 => Trial(100.210 ms)
  1 => Trial(101.195 ms)
  6 => Trial(101.193 ms)
  11 => Trial(101.157 ms)
  9 => Trial(101.155 ms)
  3 => Trial(100.295 ms)
  7 => Trial(101.191 ms)
  4 => Trial(100.208 ms)
  2 => Trial(100.295 ms)
  10 => Trial(100.329 ms)
  ⋮
```

With the first commit it prints ten entries followed by vertical dots:

```julia
11-element BenchmarkTools.BenchmarkGroup:
  tags: []
  5 => Trial(100.185 ms)
  8 => Trial(100.210 ms)
  1 => Trial(101.195 ms)
  6 => Trial(101.193 ms)
  11 => Trial(101.157 ms)
  9 => Trial(101.155 ms)
  3 => Trial(100.295 ms)
  7 => Trial(101.191 ms)
  4 => Trial(100.208 ms)
  2 => Trial(100.295 ms)
  ⋮
```

With both commits combined it prints the eleventh entry and no vertical dots in this special case:

```julia
11-element BenchmarkTools.BenchmarkGroup:
  tags: []
  5 => Trial(100.185 ms)
  8 => Trial(100.210 ms)
  1 => Trial(101.195 ms)
  6 => Trial(101.193 ms)
  11 => Trial(101.157 ms)
  9 => Trial(101.155 ms)
  3 => Trial(100.295 ms)
  7 => Trial(101.191 ms)
  4 => Trial(100.208 ms)
  2 => Trial(100.295 ms)
  10 => Trial(100.329 ms)
```