### PR TITLE
Show trials with 1 sample without error

### DIFF
--- a/test/TrialsTests.jl
+++ b/test/TrialsTests.jl
@@ -214,6 +214,9 @@ BenchmarkTools.TrialEstimate:
 
 @test sprint(show, [ta, tb]) == "BenchmarkTools.TrialEstimate[0.490 ns, 1.000 ns]"
 
+trial1sample = BenchmarkTools.Trial(BenchmarkTools.Parameters(), [1], [1], 1, 1)
+@test try display(trial1sample); true catch e false end
+
 @static if VERSION < v"1.6-"
 
 @test sprint(show, "text/plain", [ta, tb]) == """


### PR DESCRIPTION
When only a single sample is present, show the info on that one result.
Also, use plurals appropriately with sample(s) and evaluation(s).

This should resolve #228.

Sample:

![image](https://user-images.githubusercontent.com/20903656/125629075-5c5ccc9d-e18e-48b5-aaa1-c0900bff59ff.png)
