### PR TITLE
remove sorting of Trial

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -104,7 +104,7 @@ function _run(b::Benchmark, p::Parameters; verbose = false, pad = "", kwargs...)
          push!(trial, b.samplefunc(params)[1:end-1]...)
          iters += 1
     end
-    return sort!(trial), return_val
+    return trial, return_val
 end
 
 


### PR DESCRIPTION
Closes https://github.com/JuliaCI/BenchmarkTools.jl/issues/179

I don't think this really needs an option to sort the data, you can just do that yourself.