### PR TITLE
Add Documenter SSH key to TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -11,4 +11,5 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Without this, documentation on tags isn't built at all