### PR TITLE
Fix compatibility with Julia v1.0

### DIFF
--- a/src/trials.jl
+++ b/src/trials.jl
@@ -466,13 +466,7 @@ function Base.show(io::IO, ::MIME"text/plain", t::Trial)
         end
     end
 
-    function remtrailingzeros(timestr)
-        if match(r"\.0+$", timestr) !== nothing
-            replace(timestr, r"\.0+$" => "")
-        else
-            replace(timestr, r"(\.\d+?)0+$" => s"\1")
-        end
-    end
+    remtrailingzeros(timestr) = replace(timestr, r"\.?0+ " => " ")
     minhisttime, maxhisttime = remtrailingzeros.(prettytime.(round.(histtimes[[1; end]], sigdigits=3)))
 
     print(io, "\n", pad, "  ", minhisttime)

--- a/src/trials.jl
+++ b/src/trials.jl
@@ -456,9 +456,8 @@ function Base.show(io::IO, ::MIME"text/plain", t::Trial)
 
     print(io, "\n")
     for r in axes(hist, 1)
-        histrow = view(hist, r, :)
         print(io, "\n", pad, "  ")
-        for (i, bar) in enumerate(histrow)
+        for (i, bar) in enumerate(view(hist, r, :))
             color = :default
             if i == avgpos color = :green end
             if i == medpos color = :blue end

--- a/src/trials.jl
+++ b/src/trials.jl
@@ -455,7 +455,8 @@ function Base.show(io::IO, ::MIME"text/plain", t::Trial)
     end
 
     print(io, "\n")
-    for histrow in eachrow(hist)
+    for r in axes(hist, 1)
+        histrow = view(hist, r, :)
         print(io, "\n", pad, "  ")
         for (i, bar) in enumerate(histrow)
             color = :default
@@ -466,7 +467,7 @@ function Base.show(io::IO, ::MIME"text/plain", t::Trial)
     end
 
     function remtrailingzeros(timestr)
-        if ! isnothing(match(r"\.0+$", timestr))
+        if match(r"\.0+$", timestr) !== nothing
             replace(timestr, r"\.0+$" => "")
         else
             replace(timestr, r"(\.\d+?)0+$" => s"\1")

--- a/test/TrialsTests.jl
+++ b/test/TrialsTests.jl
@@ -233,4 +233,17 @@ else
 
 end
 
+trial = BenchmarkTools.Trial(BenchmarkTools.Parameters(), [1.0, 1.01], [0.0, 0.0], 0, 0)
+@test sprint(show, "text/plain", trial) == """
+BenchmarkTools.Trial: 2 samples with 1 evaluation.
+ Range (min … max):  1.000 ns … 1.010 ns  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     1.005 ns             ┊ GC (median):    0.00%
+ Time  (mean ± σ):   1.005 ns ± 0.007 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+  █                                                       █  
+  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
+  1 ns           Histogram: frequency by time       1.01 ns <
+
+ Memory estimate: 0 bytes, allocs estimate: 0."""
+
 end # module


### PR DESCRIPTION
In Julia v1.0, the use of `eachrow` and `isnothing` breaks the printing of benchmark results as they were only added in v1.1. This PR replaces them with compatible alternatives.