### PR TITLE
Add note about memory of interpolated variables to manual

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -208,6 +208,9 @@ julia> let x = 1
        end
 ```
 
+!!! warning
+    Interpolated variables become part of the global scope and their memory won't be freed by the garbage collector until the Julia process is terminated.
+
 ### Setup and teardown phases
 
 BenchmarkTools allows you to pass `setup` and `teardown` expressions to `@benchmark` and `@benchmarkable`. The `setup` expression is evaluated just before sample execution, while the `teardown` expression is evaluated just after sample execution. Here's an example where this kind of thing is useful:


### PR DESCRIPTION
As mentioned in https://github.com/JuliaCI/BenchmarkTools.jl/issues/214, I think it would be a good idea to document somewhere that variables interpolated into a benchmark won’t get garbage collected. Feel free to change or move the note.