### PR TITLE
Make sure times are sorted in the `at-benchmark` histogram

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BenchmarkTools"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-version = "1.1.3"
+version = "1.1.4"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"


### PR DESCRIPTION
Before (see #249):
```julia
julia> b = @benchmark $a[$w] .= $b[$w];

julia> b
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):   9.983 μs …  1.133 ms  ┊ GC (min … max): 0.00% … 98.94%
 Time  (median):     10.765 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.441 μs ± 19.772 μs  ┊ GC (mean ± σ):  3.75% ±  2.72%

  █                                                            
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▁
  39.3 μs         Histogram: frequency by time        20.5 μs <

 Memory estimate: 38.89 KiB, allocs estimate: 2.
```
After:
```julia
julia> b
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):   9.983 μs …  1.133 ms  ┊ GC (min … max): 0.00% … 98.94%
 Time  (median):     10.765 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.441 μs ± 19.772 μs  ┊ GC (mean ± σ):  3.75% ±  2.72%

  ▆▇█▅▄▂        ▁▁              ▂▂▂▃▃▂▃▃▂▁▁▁                  ▂
  ███████▅▆▆▅▄▄▄██▅▄▄▄▃▁▃▅▃▄▄▆▇████████████████▇█▆▇▇▆▅▆▆▆▅▅▅▆ █
  9.98 μs      Histogram: log(frequency) by time      29.2 μs <

 Memory estimate: 38.89 KiB, allocs estimate: 2.
```
I don't know how no one else noted that all histograms were broken.

I'm not an expert of `BenchmarkTools` internals, please triple check I didn't mess up anything.  For example, I'm assuming `times` and `gctimes` should be sorted together, but I'm not completely sure about it.

Fix #249.  CC: @tecosaur 