### PR TITLE
Ensure interpolated variables are garbage-collectable

### DIFF
--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -253,4 +253,13 @@ let time = 2
     @benchmark identity(time)
 end
 
+# Ensure that interpolated values are garbage-collectable
+x = []
+x_finalized = false
+finalizer(x->(global x_finalized=true), x)
+b = @benchmarkable $x
+b = x = nothing
+GC.gc()
+@test x_finalized
+
 end # module


### PR DESCRIPTION
With this PR, the values interpolated into an `@benchmarkable` are stored in the `Benchmark` object rather than interpolated directly into the benchmark code. This ensures that interpolated values can be garbage-collected once the `Benchmark` object goes out of scope, in contrast to the current behaviour where values interpolated into a benchmark expression will stick around forever. 

This PR would solve https://github.com/JuliaCI/BenchmarkTools.jl/issues/127. 

MWE demonstrating what works with this PR but fails otherwise:
```julia
# Assemble a benchmark with an interpolated value
x = []
x_finalized = false
finalizer(x->(global x_finalized=true), x)
b = @benchmarkable $x

# Free the memory
b = x = nothing
GC.gc()

# Check that the memory has indeed been freed
@test x_finalized
```