### PR TITLE
Exclude internals from reference

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(;
         "Manual" => "manual.md",
         "Linux-based environments" => "linuxtips.md",
         "Reference" => "reference.md",
+        hide("Internals" => "internals.md"),
     ],
 )
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,0 +1,7 @@
+# Internals
+
+```@autodocs
+Modules = [BenchmarkTools]
+Public = false
+Filter = f -> f !== Base.run
+```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -2,4 +2,9 @@
 
 ```@autodocs
 Modules = [BenchmarkTools]
+Private = false
+```
+
+```@docs
+Base.run
 ```


### PR DESCRIPTION
This PR removes the internal functions from the reference documentation <https://juliaci.github.io/BenchmarkTools.jl/v1.2.0/reference/#BenchmarkTools._withprogress-Tuple{Any,%20AbstractString,%20BenchmarkGroup}>