### PR TITLE
Use Expr(:tuple) instead of Expr(:vect) to avoid vect semantics

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -443,7 +443,7 @@ macro benchmarkable(args...)
                                       $(Expr(:quote, out_vars)),
                                       $(Expr(:quote, setup_vars)),
                                       $(Expr(:quote, quote_vars)),
-                                      $(esc(Expr(:vect,Expr.(:quote, quote_vals)...))),
+                                      $(esc(Expr(:tuple,Expr.(:quote, quote_vals)...))),
                                       $(esc(Expr(:quote, core))),
                                       $(esc(Expr(:quote, setup))),
                                       $(esc(Expr(:quote, teardown))),


### PR DESCRIPTION
Fixes #270

```
julia> [[1] [2.0]]
1×2 Matrix{Float64}:
 1.0  2.0
```

Is not what we want. Alternativly we could use `Any[]`, but going with a tuple should be better.
