### PR TITLE
Make @benchmarkset work with for loop

### DIFF
--- a/src/groups.jl
+++ b/src/groups.jl
@@ -391,7 +391,7 @@ function benchmarkset_block(title, ex::Expr)
     stack = GlobalRef(BenchmarkTools, :benchmark_stack)
     quote
         let $(Symbol("#root#")) = last($stack)
-            $(Symbol("#root#"))[$title] = $(Symbol("#suite#")) = BenchmarkGroup()
+            $(Symbol("#suite#")) = $(Symbol("#root#"))[$title]
             push!($stack, $(Symbol("#suite#")))
             $ex
             pop!($stack)

--- a/test/GroupsTests.jl
+++ b/test/GroupsTests.jl
@@ -293,6 +293,16 @@ g2[[1, "a", :b]] = "hello"  # should create higher levels on the fly
     @test haskey(g1["test set"], "test case 1")
     @test haskey(g1["test set"], "test case 2")
 end
+
+@testset "benchmarkset for loop" begin
+  g1 = @benchmarkset "test set" for k in 1:2
+     @case "test case $k" $k + $k
+  end
+
+  @test haskey(g1, "test set")
+  @test haskey(g1["test set"], "test case 1")
+  @test haskey(g1["test set"], "test case 2")
+end
 # pretty printing #
 #-----------------#
 


### PR DESCRIPTION
Closes https://github.com/JuliaCI/BenchmarkTools.jl/issues/221

Fixes a bug where every iteration of the for loop
would overwrite the previous benchmark case.

Test.