### PR TITLE
Automatically create nested `BenchmarkGroup` on access

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -529,6 +529,19 @@ julia> suite
 As you might imagine, `BenchmarkGroup` supports a subset of Julia's `Associative` interface. A full list of
 these supported functions can be found [in the reference document](reference.md#benchmarkgrouptagsvector-datadict).
 
+One can also create a nested `BenchmarkGroup` simply by passing the keys, similar to how
+`mkdir -p` works:
+
+```julia
+suite2 = BenchmarkGroup()
+
+suite2["my"]["nested"]["benchmark"] = @benchmarkable sum(randn(32))
+```
+
+which will result in a hierarchical benchmark without us needing to create each `BenchmarkGroup` ourselves.
+(Note that keys are automatically created upon access, even if a key does not exist. Thus, if you wish
+to empty the unused keys, you can use `clear_empty!` to do so)
+
 ### Tuning and running a `BenchmarkGroup`
 
 Similarly to individual benchmarks, you can `tune!` and `run` whole `BenchmarkGroup` instances (following from the previous section):

--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -55,7 +55,8 @@ export BenchmarkGroup,
        addgroup!,
        leaves,
        @benchmarkset,
-       @case
+       @case,
+       clear_empty!
 
 ######################
 # Execution Strategy #

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -23,16 +23,28 @@ function addgroup!(suite::BenchmarkGroup, id, args...)
     return g
 end
 
+clear_empty!(x) = x
+function clear_empty!(group::BenchmarkGroup)
+    for (k,v) in pairs(group)
+        if v isa BenchmarkGroup && isempty(v)
+            delete!(group, k)
+        else
+            clear_empty!(v)
+        end
+    end
+    group
+end
+
 # Dict-like methods #
 #-------------------#
 
 Base.:(==)(a::BenchmarkGroup, b::BenchmarkGroup) = a.tags == b.tags && a.data == b.data
 Base.copy(group::BenchmarkGroup) = BenchmarkGroup(copy(group.tags), copy(group.data))
 Base.similar(group::BenchmarkGroup) = BenchmarkGroup(copy(group.tags), empty(group.data))
-Base.isempty(group::BenchmarkGroup) = isempty(group.data)
+Base.isempty(group::BenchmarkGroup) = isempty(clear_empty!(group).data)
 Base.length(group::BenchmarkGroup) = length(group.data)
-Base.getindex(group::BenchmarkGroup, k) = getindex(group.data, makekey(k))
-Base.getindex(group::BenchmarkGroup, k...) = getindex(group.data, makekey(k))
+Base.getindex(group::BenchmarkGroup, k) = get!(group.data, makekey(k), BenchmarkGroup())
+Base.getindex(group::BenchmarkGroup, k...) = get!(group.data, makekey(k), BenchmarkGroup())
 Base.setindex!(group::BenchmarkGroup, v, k) = setindex!(group.data, v, makekey(k))
 Base.setindex!(group::BenchmarkGroup, v, k...) = setindex!(group.data, v, makekey(k))
 Base.delete!(group::BenchmarkGroup, k) = delete!(group.data, makekey(k))


### PR DESCRIPTION
Fixes #308

This lets you perform, e.g.,

```julia
suite = BenchmarkGroup()

for T in [Float32, Float64], n in [10, 100]
    suite["sum"][T][n] = @benchmarkable sum(x) setup=(x=randn($T, $n))
end
```

without needing to manually create each benchmark group. Normally you would have to do something like:

```
suite["sum"] = BenchmarkGroup()

for T in [Float32, Float64], n in [10, 100]
    n == 10 && (suite["sum"][T] = BenchmarkGroup())
    suite["sum"][T][n] = @benchmarkable sum(x) setup=(x=randn($T, $n))
end
```

This is similar to how [EasyConfig.jl](https://github.com/JuliaComputing/EasyConfig.jl) works, in that `getindex` will automatically create each required `BenchmarkGroup()`.

The downside is that accessing the wrong key will create empty groups. Thus, there is the `clear_empty!` command to clean these up (I added docs too).