### PR TITLE
Add CI on Julia 1.9 and fix Ubuntu builds for unsupported versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,21 +16,23 @@ jobs:
       matrix:
         version:
           - '1.0'
-          - '1.5'
           - '1.6'
-          - '1.7'
-          - '1.8'
           - '1.9'
           - 'nightly'
         arch:
           - x64
+        os:
+          - ubuntu-latest
         include:
-          - version: ['1.5', '1.7']
+          - version: '1.5'
+            arch: x64
             os: ubuntu-20.04
-          - version: ['1.8']
+          - version: '1.7'
+            arch: x64
+            os: ubuntu-20.04
+          - version: '1.8'
+            arch: x64
             os: ubuntu-22.04
-          - version: ['1.0', '1.6', '1.9', 'nightly']
-            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,11 +20,19 @@ jobs:
           - '1.6'
           - '1.7'
           - '1.8'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest
         arch:
           - x64
+        include:
+          - version: ['1.5', '1.7']
+            os: ubuntu-20.04
+          - version: ['1.8']
+            os: ubuntu-22.04
+          - version: ['1.0', '1.6', '1.9', 'nightly']
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,8 +22,6 @@ jobs:
           - '1.8'
           - '1.9'
           - 'nightly'
-        os:
-          - ubuntu-latest
         arch:
           - x64
         include:


### PR DESCRIPTION
Julia versions 1.5 and 1.7 have not been supported for a while, so they didn't exist on Ubuntu 22.04

This was revealed by the update #305 

Solution:
- run tests for 1.5 and 1.7 on Ubuntu 20.04
- run tests for 1.8 on Ubuntu 22.04
- run tests for the rest on Ubuntu latest, which for now is 22.04