### PR TITLE
Apply JuliaFormatter with BlueStyle and add it to tests

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "blue"

--- a/BenchmarkPlots/src/BenchmarkPlots.jl
+++ b/BenchmarkPlots/src/BenchmarkPlots.jl
@@ -7,7 +7,7 @@ using BenchmarkTools: Trial, BenchmarkGroup
     legend --> false
     yguide --> "t / ns"
     xticks --> false
-    t.times
+    return t.times
 end
 
 @recipe function f(g::BenchmarkGroup, keys=keys(g))

--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,9 @@ julia = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Statistics", "Test"]
+test = ["Aqua", "JuliaFormatter", "Statistics", "Test"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![][docs-dev-img]][docs-dev-url]
 [![Build Status](https://github.com/JuliaCI/BenchmarkTools.jl/workflows/CI/badge.svg)](https://github.com/JuliaCI/BenchmarkTools.jl/actions/workflows/CI.yml?query=branch%3Amaster)
 [![Code Coverage](https://codecov.io/gh/JuliaCI/BenchmarkTools.jl/branch/master/graph/badge.svg?label=codecov&token=ccN7NZpkBx)](https://codecov.io/gh/JuliaCI/BenchmarkTools.jl)
+[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 BenchmarkTools makes **performance tracking of Julia code easy** by supplying a framework for **writing and running groups of benchmarks** as well as **comparing benchmark results**.

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -13,8 +13,8 @@ suite["dot"] = BenchmarkGroup(["broadcast", "elementwise"])
 teststr = join(rand(MersenneTwister(1), 'a':'d', 10^4))
 
 # Add some benchmarks to the "string" group
-suite["string"]["replace"] = @benchmarkable replace($teststr, "a", "b") seconds=Float64(π)
-suite["string"]["join"] = @benchmarkable join($teststr, $teststr) samples=42
+suite["string"]["replace"] = @benchmarkable replace($teststr, "a", "b") seconds = Float64(π)
+suite["string"]["join"] = @benchmarkable join($teststr, $teststr) samples = 42
 
 # Add some benchmarks to the "trig"/"dot" group
 for f in (sin, cos, tan)
@@ -30,8 +30,8 @@ end
 paramspath = joinpath(dirname(@__FILE__), "params.json")
 
 if isfile(paramspath)
-    loadparams!(suite, BenchmarkTools.load(paramspath)[1], :evals);
+    loadparams!(suite, BenchmarkTools.load(paramspath)[1], :evals)
 else
     tune!(suite)
-    BenchmarkTools.save(paramspath, params(suite));
+    BenchmarkTools.save(paramspath, params(suite))
 end

--- a/docs/generate_logo.jl
+++ b/docs/generate_logo.jl
@@ -8,7 +8,7 @@ JULIA_COLORS = [Luxor.julia_blue, Luxor.julia_green, Luxor.julia_red, Luxor.juli
 function draw_logo(; path, dark=false)
     Drawing(500, 500, path)
     origin()
-    squircle(O, 250, 250, :clip, rt=0.3)
+    squircle(O, 250, 250, :clip; rt=0.3)
     sethue(dark ? "black" : "white")
     paint()
 
@@ -20,11 +20,14 @@ function draw_logo(; path, dark=false)
 
         for n in 1:4
             setblend(blend(O - (240, 0), O + (240, 0), "white", JULIA_COLORS[n]))
-            sector(O,
+            sector(
+                O,
                 rescale(n, 1, 3, rmin, rmax),
                 rescale(n, 1, 3, rmin, rmax) + band,
-                3π / 2 - deg2rad(45), 3π / 2 + deg2rad(45),
-                :fill)
+                3π / 2 - deg2rad(45),
+                3π / 2 + deg2rad(45),
+                :fill,
+            )
         end
 
         sethue(dark ? "black" : "white")
@@ -37,8 +40,8 @@ function draw_logo(; path, dark=false)
     end
 
     finish()
-    preview()
+    return preview()
 end
 
-draw_logo(path=joinpath(@__DIR__, "src", "assets", "logo.svg"), dark=false)
-draw_logo(path=joinpath(@__DIR__, "src", "assets", "logo-dark.svg"), dark=true)
+draw_logo(; path=joinpath(@__DIR__, "src", "assets", "logo.svg"), dark=false)
+draw_logo(; path=joinpath(@__DIR__, "src", "assets", "logo-dark.svg"), dark=true)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,6 +21,4 @@ makedocs(;
     ],
 )
 
-deploydocs(;
-    repo="github.com/JuliaCI/BenchmarkTools.jl",
-)
+deploydocs(; repo="github.com/JuliaCI/BenchmarkTools.jl")

--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -9,7 +9,6 @@ using UUIDs: uuid4
 using Printf
 using Profile
 
-
 const BENCHMARKTOOLS_VERSION = v"1.0.0"
 
 ##############
@@ -27,19 +26,19 @@ export loadparams!
 include("trials.jl")
 
 export gctime,
-       memory,
-       allocs,
-       params,
-       ratio,
-       judge,
-       isinvariant,
-       isregression,
-       isimprovement,
-       median,
-       mean,
-       rmskew!,
-       rmskew,
-       trim
+    memory,
+    allocs,
+    params,
+    ratio,
+    judge,
+    isinvariant,
+    isregression,
+    isimprovement,
+    median,
+    mean,
+    rmskew!,
+    rmskew,
+    trim
 
 ##################
 # Benchmark Data #
@@ -48,15 +47,15 @@ export gctime,
 include("groups.jl")
 
 export BenchmarkGroup,
-       invariants,
-       regressions,
-       improvements,
-       @tagged,
-       addgroup!,
-       leaves,
-       @benchmarkset,
-       @case,
-       clear_empty!
+    invariants,
+    regressions,
+    improvements,
+    @tagged,
+    addgroup!,
+    leaves,
+    @benchmarkset,
+    @case,
+    clear_empty!
 
 ######################
 # Execution Strategy #
@@ -64,14 +63,7 @@ export BenchmarkGroup,
 
 include("execution.jl")
 
-export tune!,
-       warmup,
-       @ballocated,
-       @benchmark,
-       @benchmarkable,
-       @belapsed,
-       @btime,
-       @bprofile
+export tune!, warmup, @ballocated, @benchmark, @benchmarkable, @belapsed, @btime, @bprofile
 
 #################
 # Serialization #

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -19,23 +19,41 @@ end
 
 const DEFAULT_PARAMETERS = Parameters(5.0, 10000, 1, false, 0, true, false, 0.05, 0.01)
 
-function Parameters(; seconds = DEFAULT_PARAMETERS.seconds,
-                    samples = DEFAULT_PARAMETERS.samples,
-                    evals = DEFAULT_PARAMETERS.evals,
-                    evals_set = DEFAULT_PARAMETERS.evals_set,
-                    overhead = DEFAULT_PARAMETERS.overhead,
-                    gctrial = DEFAULT_PARAMETERS.gctrial,
-                    gcsample = DEFAULT_PARAMETERS.gcsample,
-                    time_tolerance = DEFAULT_PARAMETERS.time_tolerance,
-                    memory_tolerance = DEFAULT_PARAMETERS.memory_tolerance)
-    return Parameters(seconds, samples, evals, evals_set, overhead, gctrial,
-                      gcsample, time_tolerance, memory_tolerance)
+function Parameters(;
+    seconds=DEFAULT_PARAMETERS.seconds,
+    samples=DEFAULT_PARAMETERS.samples,
+    evals=DEFAULT_PARAMETERS.evals,
+    evals_set=DEFAULT_PARAMETERS.evals_set,
+    overhead=DEFAULT_PARAMETERS.overhead,
+    gctrial=DEFAULT_PARAMETERS.gctrial,
+    gcsample=DEFAULT_PARAMETERS.gcsample,
+    time_tolerance=DEFAULT_PARAMETERS.time_tolerance,
+    memory_tolerance=DEFAULT_PARAMETERS.memory_tolerance,
+)
+    return Parameters(
+        seconds,
+        samples,
+        evals,
+        evals_set,
+        overhead,
+        gctrial,
+        gcsample,
+        time_tolerance,
+        memory_tolerance,
+    )
 end
 
-function Parameters(default::Parameters; seconds = nothing, samples = nothing,
-                    evals = nothing, overhead = nothing, gctrial = nothing,
-                    gcsample = nothing, time_tolerance = nothing,
-                    memory_tolerance = nothing)
+function Parameters(
+    default::Parameters;
+    seconds=nothing,
+    samples=nothing,
+    evals=nothing,
+    overhead=nothing,
+    gctrial=nothing,
+    gcsample=nothing,
+    time_tolerance=nothing,
+    memory_tolerance=nothing,
+)
     params = Parameters()
     params.seconds = seconds != nothing ? seconds : default.seconds
     params.samples = samples != nothing ? samples : default.samples
@@ -43,8 +61,10 @@ function Parameters(default::Parameters; seconds = nothing, samples = nothing,
     params.overhead = overhead != nothing ? overhead : default.overhead
     params.gctrial = gctrial != nothing ? gctrial : default.gctrial
     params.gcsample = gcsample != nothing ? gcsample : default.gcsample
-    params.time_tolerance = time_tolerance != nothing ? time_tolerance : default.time_tolerance
-    params.memory_tolerance = memory_tolerance != nothing ? memory_tolerance : default.memory_tolerance
+    params.time_tolerance =
+        time_tolerance != nothing ? time_tolerance : default.time_tolerance
+    params.memory_tolerance =
+        memory_tolerance != nothing ? memory_tolerance : default.memory_tolerance
     return params::BenchmarkTools.Parameters
 end
 
@@ -59,17 +79,19 @@ function Base.:(==)(a::Parameters, b::Parameters)
            a.memory_tolerance == b.memory_tolerance
 end
 
-Base.copy(p::Parameters) = Parameters(
-    p.seconds,
-    p.samples,
-    p.evals,
-    p.evals_set,
-    p.overhead,
-    p.gctrial,
-    p.gcsample,
-    p.time_tolerance,
-    p.memory_tolerance
-)
+function Base.copy(p::Parameters)
+    return Parameters(
+        p.seconds,
+        p.samples,
+        p.evals,
+        p.evals_set,
+        p.overhead,
+        p.gctrial,
+        p.gcsample,
+        p.time_tolerance,
+        p.memory_tolerance,
+    )
+end
 
 function loadparams!(a::Parameters, b::Parameters, fields...)
     fields = isempty(fields) ? fieldnames(Parameters) : fields

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -1,23 +1,32 @@
-const VERSIONS = Dict("Julia" => string(VERSION),
-                      "BenchmarkTools" => string(BENCHMARKTOOLS_VERSION))
+const VERSIONS = Dict(
+    "Julia" => string(VERSION), "BenchmarkTools" => string(BENCHMARKTOOLS_VERSION)
+)
 
 # TODO: Add any new types as they're added
-const SUPPORTED_TYPES = Dict{Symbol,Type}(Base.typename(x).name => x for x in [
-    BenchmarkGroup, Parameters, TagFilter, Trial,
-    TrialEstimate, TrialJudgement, TrialRatio])
+const SUPPORTED_TYPES = Dict{Symbol,Type}(
+    Base.typename(x).name => x for x in [
+        BenchmarkGroup,
+        Parameters,
+        TagFilter,
+        Trial,
+        TrialEstimate,
+        TrialJudgement,
+        TrialRatio,
+    ]
+)
 # n.b. Benchmark type not included here, since it is gensym'd
 
 function JSON.lower(x::Union{values(SUPPORTED_TYPES)...})
     d = Dict{String,Any}()
     T = typeof(x)
-    for i = 1:nfields(x)
+    for i in 1:nfields(x)
         name = String(fieldname(T, i))
         field = getfield(x, i)
         ft = typeof(field)
         value = ft <: get(SUPPORTED_TYPES, nameof(ft), Union{}) ? JSON.lower(field) : field
         d[name] = value
     end
-    [string(nameof(typeof(x))), d]
+    return [string(nameof(typeof(x))), d]
 end
 
 # a minimal 'eval' function, mirroring KeyTypes, but being slightly more lenient
@@ -27,17 +36,18 @@ function safeeval(x::Expr)
     x.head === :quote && return x.args[1]
     x.head === :inert && return x.args[1]
     x.head === :tuple && return ((safeeval(a) for a in x.args)...,)
-    x
+    return x
 end
 function recover(x::Vector)
     length(x) == 2 || throw(ArgumentError("Expecting a vector of length 2"))
     typename = x[1]::String
     fields = x[2]::Dict
-    startswith(typename, "BenchmarkTools.") && (typename = typename[sizeof("BenchmarkTools.")+1:end])
+    startswith(typename, "BenchmarkTools.") &&
+        (typename = typename[(sizeof("BenchmarkTools.") + 1):end])
     T = SUPPORTED_TYPES[Symbol(typename)]
     fc = fieldcount(T)
     xs = Vector{Any}(undef, fc)
-    for i = 1:fc
+    for i in 1:fc
         ft = fieldtype(T, i)
         fn = String(fieldname(T, i))
         if ft <: get(SUPPORTED_TYPES, nameof(ft), Union{})
@@ -49,7 +59,7 @@ function recover(x::Vector)
             for (k, v) in copy(xsi)
                 k = k::String
                 if startswith(k, "(") || startswith(k, ":")
-                    kt = Meta.parse(k, raise=false)
+                    kt = Meta.parse(k; raise=false)
                     if !(kt isa Expr && kt.head === :error)
                         delete!(xsi, k)
                         k = safeeval(kt)
@@ -63,7 +73,7 @@ function recover(x::Vector)
         end
         xs[i] = xsi
     end
-    T(xs...)
+    return T(xs...)
 end
 
 function badext(filename)
@@ -91,9 +101,11 @@ function save(io::IO, args...)
     goodargs = Any[]
     for arg in args
         if arg isa String
-            @warn("Naming variables in serialization is no longer supported.\n" *
-                  "The name will be ignored and the object will be serialized " *
-                  "in the order it appears in the input.")
+            @warn(
+                "Naming variables in serialization is no longer supported.\n" *
+                    "The name will be ignored and the object will be serialized " *
+                    "in the order it appears in the input."
+            )
             continue
         elseif !(arg isa get(SUPPORTED_TYPES, nameof(typeof(arg)), Union{}))
             throw(ArgumentError("Only BenchmarkTools types can be serialized."))
@@ -101,7 +113,7 @@ function save(io::IO, args...)
         push!(goodargs, arg)
     end
     isempty(goodargs) && error("Nothing to save")
-    JSON.print(io, [VERSIONS, goodargs])
+    return JSON.print(io, [VERSIONS, goodargs])
 end
 
 function load(filename::AbstractString, args...)
@@ -113,14 +125,21 @@ end
 
 function load(io::IO, args...)
     if !isempty(args)
-        throw(ArgumentError("Looking up deserialized values by name is no longer supported, " *
-                            "as names are no longer saved."))
+        throw(
+            ArgumentError(
+                "Looking up deserialized values by name is no longer supported, " *
+                "as names are no longer saved.",
+            ),
+        )
     end
     parsed = JSON.parse(io)
-    if !isa(parsed, Vector) || length(parsed) != 2 || !isa(parsed[1], Dict) || !isa(parsed[2], Vector)
+    if !isa(parsed, Vector) ||
+        length(parsed) != 2 ||
+        !isa(parsed[1], Dict) ||
+        !isa(parsed[2], Vector)
         error("Unexpected JSON format. Was this file originally written by BenchmarkTools?")
     end
     versions = parsed[1]::Dict
     values = parsed[2]::Vector
-    map!(recover, values, values)
+    return map!(recover, values, values)
 end

--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -19,13 +19,15 @@ sizes = (5, 10, 20)
 
 for s in sizes
     A = rand(s, s)
-    groups["sum"][s] = @benchmarkable sum($A) seconds=3
-    groups["sin"][s] = @benchmarkable(sin($s), seconds=1, gctrial=false)
+    groups["sum"][s] = @benchmarkable sum($A) seconds = 3
+    groups["sin"][s] = @benchmarkable(sin($s), seconds = 1, gctrial = false)
 end
 
 groups["special"]["macro"] = @benchmarkable @test(1 == 1)
 groups["special"]["nothing"] = @benchmarkable nothing
-groups["special"]["block"] = @benchmarkable begin rand(3) end
+groups["special"]["block"] = @benchmarkable begin
+    rand(3)
+end
 groups["special"]["comprehension"] = @benchmarkable [s^2 for s in sizes]
 
 function testexpected(received::BenchmarkGroup, expected::BenchmarkGroup)
@@ -53,8 +55,8 @@ for id in keys(groups["special"])
     testexpected(tune!(groups["special"][id]))
 end
 
-testexpected(tune!(groups["sin"], verbose = true), groups["sin"])
-testexpected(tune!(groups, verbose = true), groups)
+testexpected(tune!(groups["sin"]; verbose=true), groups["sin"])
+testexpected(tune!(groups; verbose=true), groups)
 
 oldgroupscopy = copy(oldgroups)
 
@@ -65,46 +67,80 @@ loadparams!(oldgroups, params(groups))
 
 # Explicitly set evals should not get tuned
 
-b = @benchmarkable sin(1) evals=1
+b = @benchmarkable sin(1) evals = 1
 tune!(b)
 @test params(b).evals == 1
 
-b = @benchmarkable sin(1) evals=10
+b = @benchmarkable sin(1) evals = 10
 tune!(b)
 @test params(b).evals == 10
 
 function test_length_and_push!(x::AbstractVector)
     length(x) == 2 || error("setup not correctly executed")
-    push!(x, randn())
+    return push!(x, randn())
 end
 
-b_fail = @benchmarkable test_length_and_push!(y) setup=(y=randn(2))
+b_fail = @benchmarkable test_length_and_push!(y) setup = (y = randn(2))
 @test_throws Exception tune!(b_fail)
 
-b_pass = @benchmarkable test_length_and_push!(y) setup=(y=randn(2)) evals=1
+b_pass = @benchmarkable test_length_and_push!(y) setup = (y = randn(2)) evals = 1
 @test tune!(b_pass) isa BenchmarkTools.Benchmark
 
 #######
 # run #
 #######
 
-testexpected(run(groups; verbose = true), groups)
-testexpected(run(groups; seconds = 1, verbose = true, gctrial = false), groups)
-testexpected(run(groups; verbose = true, seconds = 1, gctrial = false, time_tolerance = 0.10, samples = 2, evals = 2, gcsample = false), groups)
+testexpected(run(groups; verbose=true), groups)
+testexpected(run(groups; seconds=1, verbose=true, gctrial=false), groups)
+testexpected(
+    run(
+        groups;
+        verbose=true,
+        seconds=1,
+        gctrial=false,
+        time_tolerance=0.10,
+        samples=2,
+        evals=2,
+        gcsample=false,
+    ),
+    groups,
+)
 
-testexpected(run(groups["sin"]; verbose = true), groups["sin"])
-testexpected(run(groups["sin"]; seconds = 1, verbose = true, gctrial = false), groups["sin"])
-testexpected(run(groups["sin"]; verbose = true, seconds = 1, gctrial = false, time_tolerance = 0.10, samples = 2, evals = 2, gcsample = false), groups["sin"])
+testexpected(run(groups["sin"]; verbose=true), groups["sin"])
+testexpected(run(groups["sin"]; seconds=1, verbose=true, gctrial=false), groups["sin"])
+testexpected(
+    run(
+        groups["sin"];
+        verbose=true,
+        seconds=1,
+        gctrial=false,
+        time_tolerance=0.10,
+        samples=2,
+        evals=2,
+        gcsample=false,
+    ),
+    groups["sin"],
+)
 
 testexpected(run(groups["sin"][first(sizes)]))
-testexpected(run(groups["sin"][first(sizes)]; seconds = 1, gctrial = false))
-testexpected(run(groups["sin"][first(sizes)]; seconds = 1, gctrial = false, time_tolerance = 0.10, samples = 2, evals = 2, gcsample = false))
+testexpected(run(groups["sin"][first(sizes)]; seconds=1, gctrial=false))
+testexpected(
+    run(
+        groups["sin"][first(sizes)];
+        seconds=1,
+        gctrial=false,
+        time_tolerance=0.10,
+        samples=2,
+        evals=2,
+        gcsample=false,
+    ),
+)
 
 testexpected(run(groups["sum"][first(sizes)], BenchmarkTools.DEFAULT_PARAMETERS))
 
 # Mutating benchmark
 
-b_pass = @benchmarkable test_length_and_push!(y) setup=(y=randn(2)) evals=1
+b_pass = @benchmarkable test_length_and_push!(y) setup = (y = randn(2)) evals = 1
 tune!(b_pass)
 @test run(b_pass) isa BenchmarkTools.Trial
 
@@ -129,13 +165,15 @@ end
 
 const foo = Foo(-1)
 
-t = @benchmark sin(foo.x) evals=3 samples=10 setup=(foo.x = 0)
+t = @benchmark sin(foo.x) evals = 3 samples = 10 setup = (foo.x = 0)
 
 @test foo.x == 0
 @test params(t).evals == 3
 @test params(t).samples == 10
 
-b = @benchmarkable sin(x) setup=(foo.x = -1; x = foo.x) teardown=(@assert(x == -1); foo.x = 1)
+b = @benchmarkable sin(x) setup = (foo.x = -1; x = foo.x) teardown = (
+    @assert(x == -1); foo.x = 1
+)
 tune!(b)
 
 @test foo.x == 1
@@ -148,42 +186,70 @@ tune!(b)
 @test params(b).evals > 100
 
 # test variable assignment with `@benchmark args...` form
-@benchmark local_var="good" setup=(local_var="bad") teardown=(@test local_var=="good")
+@benchmark local_var = "good" setup = (local_var = "bad") teardown = (@test local_var ==
+    "good")
 @test_throws UndefVarError local_var
-@benchmark some_var="whatever" teardown=(@test_throws UndefVarError some_var)
-@benchmark foo,bar="good","good" setup=(foo="bad"; bar="bad") teardown=(@test foo=="good" && bar=="good")
+@benchmark some_var = "whatever" teardown = (@test_throws UndefVarError some_var)
+@benchmark foo, bar = "good", "good" setup = (foo = "bad"; bar = "bad") teardown = (@test foo ==
+                                                                                          "good" &&
+    bar ==
+                                                                                          "good")
 
 # test variable assignment with `@benchmark(args...)` form
-@benchmark(local_var="good", setup=(local_var="bad"), teardown=(@test local_var=="good"))
+@benchmark(
+    local_var = "good", setup = (local_var = "bad"), teardown = (@test local_var == "good")
+)
 @test_throws UndefVarError local_var
-@benchmark(some_var="whatever", teardown=(@test_throws UndefVarError some_var))
-@benchmark((foo,bar) = ("good","good"), setup=(foo = "bad"; bar = "bad"), teardown=(@test foo == "good" && bar == "good"))
+@benchmark(some_var = "whatever", teardown = (@test_throws UndefVarError some_var))
+@benchmark(
+    (foo, bar) = ("good", "good"),
+    setup = (foo = "bad"; bar = "bad"),
+    teardown = (@test foo == "good" && bar == "good")
+)
 
 # test kwargs separated by `,`
-@benchmark(output=sin(x), setup=(x=1.0; output=0.0), teardown=(@test output == sin(x)))
+@benchmark(
+    output = sin(x), setup = (x = 1.0; output = 0.0), teardown = (@test output == sin(x))
+)
 
-for (tf, rex1, rex2) in ((false, r"0.5 ns +Histogram: frequency by time +8 ns",        r"Histogram: frequency"),
-                         (true,  r"0.5 ns +Histogram: log\(frequency\) by time +8 ns", r"Histogram: log\(frequency\)"))
+for (tf, rex1, rex2) in (
+    (false, r"0.5 ns +Histogram: frequency by time +8 ns", r"Histogram: frequency"),
+    (
+        true,
+        r"0.5 ns +Histogram: log\(frequency\) by time +8 ns",
+        r"Histogram: log\(frequency\)",
+    ),
+)
     io = IOBuffer()
-    ioctx = IOContext(io, :histmin=>0.5, :histmax=>8, :logbins=>tf)
+    ioctx = IOContext(io, :histmin => 0.5, :histmax => 8, :logbins => tf)
     @show tf
-    b = @benchmark x^3   setup=(x = rand()); show(ioctx, MIME("text/plain"), b)
-    b = @benchmark x^3.0 setup=(x = rand()); show(ioctx, MIME("text/plain"), b)
+    b = @benchmark x^3 setup = (x = rand())
+    show(ioctx, MIME("text/plain"), b)
+    b = @benchmark x^3.0 setup = (x = rand())
+    show(ioctx, MIME("text/plain"), b)
     str = String(take!(io))
     idx = findfirst(rex1, str)
     @test isa(idx, UnitRange)
-    idx = findnext( rex1, str, idx[end]+1)
+    idx = findnext(rex1, str, idx[end] + 1)
     @test isa(idx, UnitRange)
-    ioctx = IOContext(io, :logbins=>tf)
+    ioctx = IOContext(io, :logbins => tf)
     # A flat distribution won't trigger log by default
-    b = BenchmarkTools.Trial(BenchmarkTools.DEFAULT_PARAMETERS, 0.001 * (1:100) * 1e9, zeros(100), 0, 0)
+    b = BenchmarkTools.Trial(
+        BenchmarkTools.DEFAULT_PARAMETERS, 0.001 * (1:100) * 1e9, zeros(100), 0, 0
+    )
     show(ioctx, MIME("text/plain"), b)
     str = String(take!(io))
     idx = findfirst(rex2, str)
     @test isa(idx, UnitRange)
     # A peaked distribution will trigger log by default
     t = [fill(1, 21); 2]
-    b = BenchmarkTools.Trial(BenchmarkTools.DEFAULT_PARAMETERS, t/sum(t)*1e9*BenchmarkTools.DEFAULT_PARAMETERS.seconds, zeros(100), 0, 0)
+    b = BenchmarkTools.Trial(
+        BenchmarkTools.DEFAULT_PARAMETERS,
+        t / sum(t) * 1e9 * BenchmarkTools.DEFAULT_PARAMETERS.seconds,
+        zeros(100),
+        0,
+        0,
+    )
     show(ioctx, MIME("text/plain"), b)
     str = String(take!(io))
     idx = findfirst(rex2, str)
@@ -194,7 +260,7 @@ end
 # @bprofile #
 #############
 
-function likegcd(a::T, b::T) where T<:Base.BitInteger
+function likegcd(a::T, b::T) where {T<:Base.BitInteger}
     za = trailing_zeros(a)
     zb = trailing_zeros(b)
     k = min(za, zb)
@@ -211,22 +277,22 @@ function likegcd(a::T, b::T) where T<:Base.BitInteger
     return r % T
 end
 
-b = @bprofile likegcd(x, y) setup=(x = rand(2:200); y = rand(2:200))
+b = @bprofile likegcd(x, y) setup = (x = rand(2:200); y = rand(2:200))
 @test isa(b, BenchmarkTools.Trial)
 io = IOBuffer()
-Profile.print(IOContext(io, :displaysize=>(24,200)))
+Profile.print(IOContext(io, :displaysize => (24, 200)))
 str = String(take!(io))
-@test  occursin(r"BenchmarkTools(\.jl)?(/|\\)src(/|\\)execution\.jl:\d+; _run", str)
+@test occursin(r"BenchmarkTools(\.jl)?(/|\\)src(/|\\)execution\.jl:\d+; _run", str)
 @test !occursin(r"BenchmarkTools(\.jl)?(/|\\)src(/|\\)execution\.jl:\d+; warmup", str)
 @test !occursin(r"BenchmarkTools(\.jl)?(/|\\)src(/|\\)execution\.jl:\d+; tune!", str)
-b = @bprofile 1+1
-Profile.print(IOContext(io, :displaysize=>(24,200)))
+b = @bprofile 1 + 1
+Profile.print(IOContext(io, :displaysize => (24, 200)))
 str = String(take!(io))
 @test !occursin("gcscrub", str)
-b = @bprofile 1+1 gctrial=true
-Profile.print(IOContext(io, :displaysize=>(24,200)))
+b = @bprofile 1 + 1 gctrial = true
+Profile.print(IOContext(io, :displaysize => (24, 200)))
 str = String(take!(io))
-@test  occursin("gcscrub", str)
+@test occursin("gcscrub", str)
 
 ########
 # misc #
@@ -236,21 +302,23 @@ str = String(take!(io))
 # BenchmarkTools.DEFAULT_PARAMETERS.overhead = BenchmarkTools.estimate_overhead()
 # @test time(minimum(@benchmark nothing)) == 1
 
-@test [:x, :y, :z, :v, :w] == BenchmarkTools.collectvars(quote
-           x = 1 + 3
-           y = 1 + x
-           z = (a = 4; y + a)
-           v,w = 1,2
-           [u^2 for u in [1,2,3]]
-       end)
+@test [:x, :y, :z, :v, :w] == BenchmarkTools.collectvars(
+    quote
+        x = 1 + 3
+        y = 1 + x
+        z = (a = 4; y + a)
+        v, w = 1, 2
+        [u^2 for u in [1, 2, 3]]
+    end,
+)
 
 # this should take < 1 s on any sane machine
-@test @belapsed(sin($(foo.x)), evals=3, samples=10, setup=(foo.x = 0)) < 1
+@test @belapsed(sin($(foo.x)), evals = 3, samples = 10, setup = (foo.x = 0)) < 1
 @test @belapsed(sin(0)) < 1
 
-@test @ballocated(sin($(foo.x)), evals=3, samples=10, setup=(foo.x = 0)) == 0
+@test @ballocated(sin($(foo.x)), evals = 3, samples = 10, setup = (foo.x = 0)) == 0
 @test @ballocated(sin(0)) == 0
-@test @ballocated(Ref(1)) == 2*sizeof(Int)  # 1 for the pointer, 1 for content
+@test @ballocated(Ref(1)) == 2 * sizeof(Int)  # 1 for the pointer, 1 for content
 
 let fname = tempname()
     try
@@ -283,7 +351,7 @@ end
 # Ensure that interpolated values are garbage-collectable
 x = []
 x_finalized = false
-finalizer(x->(global x_finalized=true), x)
+finalizer(x -> (global x_finalized = true), x)
 b = @benchmarkable $x
 b = x = nothing
 GC.gc()

--- a/test/GroupsTests.jl
+++ b/test/GroupsTests.jl
@@ -16,9 +16,11 @@ seteq(a, b) = length(a) == length(b) == length(intersect(a, b))
 
 g1 = BenchmarkGroup(["1", "2"])
 
-t1a = TrialEstimate(Parameters(time_tolerance = .05, memory_tolerance = .05), 32, 1, 2, 3)
-t1b = TrialEstimate(Parameters(time_tolerance = .40, memory_tolerance = .40), 4123, 123, 43, 9)
-tc = TrialEstimate(Parameters(time_tolerance = 1.0, memory_tolerance = 1.0), 1, 1, 1, 1)
+t1a = TrialEstimate(Parameters(; time_tolerance=0.05, memory_tolerance=0.05), 32, 1, 2, 3)
+t1b = TrialEstimate(
+    Parameters(; time_tolerance=0.40, memory_tolerance=0.40), 4123, 123, 43, 9
+)
+tc = TrialEstimate(Parameters(; time_tolerance=1.0, memory_tolerance=1.0), 1, 1, 1, 1)
 
 g1["a"] = t1a
 g1["b"] = t1b
@@ -29,8 +31,10 @@ g1similar = similar(g1)
 
 g2 = BenchmarkGroup(["2", "3"])
 
-t2a = TrialEstimate(Parameters(time_tolerance = .05, memory_tolerance = .05), 323, 1, 2, 3)
-t2b = TrialEstimate(Parameters(time_tolerance = .40, memory_tolerance = .40), 1002, 123, 43, 9)
+t2a = TrialEstimate(Parameters(; time_tolerance=0.05, memory_tolerance=0.05), 323, 1, 2, 3)
+t2b = TrialEstimate(
+    Parameters(; time_tolerance=0.40, memory_tolerance=0.40), 1002, 123, 43, 9
+)
 
 g2["a"] = t2a
 g2["b"] = t2b
@@ -54,7 +58,7 @@ gtrial = BenchmarkGroup([], Dict("t" => trial))
 @test seteq(values(g1), [t1a, t1b, tc])
 @test iterate(g1) == iterate(g1.data)
 @test iterate(g1, 1) == iterate(g1.data, 1)
-@test seteq([x for x in g1], Pair["a"=>t1a, "b"=>t1b, "c"=>tc])
+@test seteq([x for x in g1], Pair["a" => t1a, "b" => t1b, "c" => tc])
 
 @test g1 == g1copy
 @test seteq(keys(delete!(g1copy, "a")), ["b", "c"])
@@ -70,13 +74,19 @@ gtrial = BenchmarkGroup([], Dict("t" => trial))
 
 @test max(g1, g2).data == Dict("a" => t2a, "b" => t1b, "c" => tc)
 @test min(g1, g2).data == Dict("a" => t1a, "b" => t2b, "c" => tc)
-@test ratio(g1, g2).data == Dict("a" => ratio(t1a, t2a), "b" => ratio(t1b, t2b), "c" => ratio(tc, tc))
-@test (judge(g1, g2; time_tolerance = 0.1, memory_tolerance = 0.1).data ==
-       Dict("a" => judge(t1a, t2a; time_tolerance = 0.1, memory_tolerance = 0.1),
-            "b" => judge(t1b, t2b; time_tolerance = 0.1, memory_tolerance = 0.1),
-            "c" => judge(tc, tc; time_tolerance = 0.1, memory_tolerance = 0.1)))
-@test (judge(ratio(g1, g2); time_tolerance = 0.1, memory_tolerance = 0.1) ==
-       judge(g1, g2; time_tolerance = 0.1, memory_tolerance = 0.1))
+@test ratio(g1, g2).data ==
+    Dict("a" => ratio(t1a, t2a), "b" => ratio(t1b, t2b), "c" => ratio(tc, tc))
+@test (
+    judge(g1, g2; time_tolerance=0.1, memory_tolerance=0.1).data == Dict(
+        "a" => judge(t1a, t2a; time_tolerance=0.1, memory_tolerance=0.1),
+        "b" => judge(t1b, t2b; time_tolerance=0.1, memory_tolerance=0.1),
+        "c" => judge(tc, tc; time_tolerance=0.1, memory_tolerance=0.1),
+    )
+)
+@test (
+    judge(ratio(g1, g2); time_tolerance=0.1, memory_tolerance=0.1) ==
+    judge(g1, g2; time_tolerance=0.1, memory_tolerance=0.1)
+)
 @test ratio(g1, g2) == ratio(judge(g1, g2))
 
 @test isinvariant(judge(g1, g1))
@@ -91,12 +101,14 @@ gtrial = BenchmarkGroup([], Dict("t" => trial))
 
 @test BenchmarkTools.invariants(judge(g1, g2)).data == Dict("c" => judge(tc, tc))
 @test BenchmarkTools.invariants(time, (judge(g1, g2))).data == Dict("c" => judge(tc, tc))
-@test BenchmarkTools.invariants(memory, (judge(g1, g2))).data == Dict("a" => judge(t1a, t2a), "b" => judge(t1b, t2b), "c" => judge(tc, tc))
+@test BenchmarkTools.invariants(memory, (judge(g1, g2))).data ==
+    Dict("a" => judge(t1a, t2a), "b" => judge(t1b, t2b), "c" => judge(tc, tc))
 @test BenchmarkTools.regressions(judge(g1, g2)).data == Dict("b" => judge(t1b, t2b))
 @test BenchmarkTools.regressions(time, (judge(g1, g2))).data == Dict("b" => judge(t1b, t2b))
 @test BenchmarkTools.regressions(memory, (judge(g1, g2))).data == Dict()
 @test BenchmarkTools.improvements(judge(g1, g2)).data == Dict("a" => judge(t1a, t2a))
-@test BenchmarkTools.improvements(time, (judge(g1, g2))).data == Dict("a" => judge(t1a, t2a))
+@test BenchmarkTools.improvements(time, (judge(g1, g2))).data ==
+    Dict("a" => judge(t1a, t2a))
 @test BenchmarkTools.improvements(memory, (judge(g1, g2))).data == Dict()
 
 @test isinvariant(judge(g1, g1))
@@ -139,8 +151,12 @@ groupsa = BenchmarkGroup()
 groupsa["g1"] = g1
 groupsa["g2"] = g2
 g3a = addgroup!(groupsa, "g3", ["3", "4"])
-g3a["c"] = TrialEstimate(Parameters(time_tolerance = .05, memory_tolerance = .05), 6341, 23, 41, 536)
-g3a["d"] = TrialEstimate(Parameters(time_tolerance = .13, memory_tolerance = .13), 12341, 3013, 2, 150)
+g3a["c"] = TrialEstimate(
+    Parameters(; time_tolerance=0.05, memory_tolerance=0.05), 6341, 23, 41, 536
+)
+g3a["d"] = TrialEstimate(
+    Parameters(; time_tolerance=0.13, memory_tolerance=0.13), 12341, 3013, 2, 150
+)
 
 groups_copy = copy(groupsa)
 groups_similar = similar(groupsa)
@@ -149,8 +165,12 @@ groupsb = BenchmarkGroup()
 groupsb["g1"] = g1
 groupsb["g2"] = g2
 g3b = addgroup!(groupsb, "g3", ["3", "4"])
-g3b["c"] = TrialEstimate(Parameters(time_tolerance = .05, memory_tolerance = .05), 1003, 23, 41, 536)
-g3b["d"] = TrialEstimate(Parameters(time_tolerance = .23, memory_tolerance = .23), 25341, 3013, 2, 150)
+g3b["c"] = TrialEstimate(
+    Parameters(; time_tolerance=0.05, memory_tolerance=0.05), 1003, 23, 41, 536
+)
+g3b["d"] = TrialEstimate(
+    Parameters(; time_tolerance=0.23, memory_tolerance=0.23), 25341, 3013, 2, 150
+)
 
 groupstrial = BenchmarkGroup()
 groupstrial["g"] = gtrial
@@ -159,24 +179,36 @@ groupstrial["g"] = gtrial
 #-------#
 
 @test time(groupsa).data == Dict("g1" => time(g1), "g2" => time(g2), "g3" => time(g3a))
-@test gctime(groupsa).data == Dict("g1" => gctime(g1), "g2" => gctime(g2), "g3" => gctime(g3a))
-@test memory(groupsa).data == Dict("g1" => memory(g1), "g2" => memory(g2), "g3" => memory(g3a))
-@test allocs(groupsa).data == Dict("g1" => allocs(g1), "g2" => allocs(g2), "g3" => allocs(g3a))
-@test params(groupsa).data == Dict("g1" => params(g1), "g2" => params(g2), "g3" => params(g3a))
+@test gctime(groupsa).data ==
+    Dict("g1" => gctime(g1), "g2" => gctime(g2), "g3" => gctime(g3a))
+@test memory(groupsa).data ==
+    Dict("g1" => memory(g1), "g2" => memory(g2), "g3" => memory(g3a))
+@test allocs(groupsa).data ==
+    Dict("g1" => allocs(g1), "g2" => allocs(g2), "g3" => allocs(g3a))
+@test params(groupsa).data ==
+    Dict("g1" => params(g1), "g2" => params(g2), "g3" => params(g3a))
 
 for (k, v) in BenchmarkTools.leaves(groupsa)
     @test groupsa[k] == v
 end
 
-@test max(groupsa, groupsb).data == Dict("g1" => max(g1, g1), "g2" => max(g2, g2), "g3" => max(g3a, g3b))
-@test min(groupsa, groupsb).data == Dict("g1" => min(g1, g1), "g2" => min(g2, g2), "g3" => min(g3a, g3b))
-@test ratio(groupsa, groupsb).data == Dict("g1" => ratio(g1, g1), "g2" => ratio(g2, g2), "g3" => ratio(g3a, g3b))
-@test (judge(groupsa, groupsb; time_tolerance = 0.1, memory_tolerance = 0.1).data ==
-       Dict("g1" => judge(g1, g1; time_tolerance = 0.1, memory_tolerance = 0.1),
-            "g2" => judge(g2, g2; time_tolerance = 0.1, memory_tolerance = 0.1),
-            "g3" => judge(g3a, g3b; time_tolerance = 0.1, memory_tolerance = 0.1)))
-@test (judge(ratio(groupsa, groupsb); time_tolerance = 0.1, memory_tolerance = 0.1) ==
-       judge(groupsa, groupsb; time_tolerance = 0.1, memory_tolerance = 0.1))
+@test max(groupsa, groupsb).data ==
+    Dict("g1" => max(g1, g1), "g2" => max(g2, g2), "g3" => max(g3a, g3b))
+@test min(groupsa, groupsb).data ==
+    Dict("g1" => min(g1, g1), "g2" => min(g2, g2), "g3" => min(g3a, g3b))
+@test ratio(groupsa, groupsb).data ==
+    Dict("g1" => ratio(g1, g1), "g2" => ratio(g2, g2), "g3" => ratio(g3a, g3b))
+@test (
+    judge(groupsa, groupsb; time_tolerance=0.1, memory_tolerance=0.1).data == Dict(
+        "g1" => judge(g1, g1; time_tolerance=0.1, memory_tolerance=0.1),
+        "g2" => judge(g2, g2; time_tolerance=0.1, memory_tolerance=0.1),
+        "g3" => judge(g3a, g3b; time_tolerance=0.1, memory_tolerance=0.1),
+    )
+)
+@test (
+    judge(ratio(groupsa, groupsb); time_tolerance=0.1, memory_tolerance=0.1) ==
+    judge(groupsa, groupsb; time_tolerance=0.1, memory_tolerance=0.1)
+)
 @test ratio(groupsa, groupsb) == ratio(judge(groupsa, groupsb))
 
 @test isinvariant(judge(groupsa, groupsa))
@@ -185,9 +217,12 @@ end
 @test !(isregression(judge(groupsa, groupsa)))
 @test isimprovement(judge(groupsa, groupsb))
 @test !(isimprovement(judge(groupsa, groupsa)))
-@test invariants(judge(groupsa, groupsb)).data == Dict("g1" => judge(g1, g1), "g2" => judge(g2, g2))
-@test regressions(judge(groupsa, groupsb)).data == Dict("g3" => regressions(judge(g3a, g3b)))
-@test improvements(judge(groupsa, groupsb)).data == Dict("g3" => improvements(judge(g3a, g3b)))
+@test invariants(judge(groupsa, groupsb)).data ==
+    Dict("g1" => judge(g1, g1), "g2" => judge(g2, g2))
+@test regressions(judge(groupsa, groupsb)).data ==
+    Dict("g3" => regressions(judge(g3a, g3b)))
+@test improvements(judge(groupsa, groupsb)).data ==
+    Dict("g3" => improvements(judge(g3a, g3b)))
 
 @test minimum(groupstrial)["g"]["t"] == minimum(groupstrial["g"]["t"])
 @test maximum(groupstrial)["g"]["t"] == maximum(groupstrial["g"]["t"])
@@ -212,36 +247,49 @@ end
 @test groupsa[@tagged ALL] == groupsa
 @test groupsa[@tagged !("1" || "3") && !("4")] == similar(groupsa)
 
-gnest = BenchmarkGroup(["1"],
-                       "2" => BenchmarkGroup(["3"], 1 => 1),
-                       4 => BenchmarkGroup(["3"], 5 => 6),
-                       7 => 8,
-                       "a" => BenchmarkGroup(["3"], "a" => :a, (11, "b") => :b),
-                       9 => BenchmarkGroup(["2"],
-                                           10 => BenchmarkGroup(["3"]),
-                                           11 => BenchmarkGroup()))
+gnest = BenchmarkGroup(
+    ["1"],
+    "2" => BenchmarkGroup(["3"], 1 => 1),
+    4 => BenchmarkGroup(["3"], 5 => 6),
+    7 => 8,
+    "a" => BenchmarkGroup(["3"], "a" => :a, (11, "b") => :b),
+    9 => BenchmarkGroup(["2"], 10 => BenchmarkGroup(["3"]), 11 => BenchmarkGroup()),
+)
 
-@test sort(leaves(gnest), by=string) ==
-      Any[(Any["2",1],1), (Any["a","a"],:a), (Any["a",(11,"b")],:b), (Any[4,5],6), (Any[7],8)]
+@test sort(leaves(gnest); by=string) == Any[
+    (Any["2", 1], 1),
+    (Any["a", "a"], :a),
+    (Any["a", (11, "b")], :b),
+    (Any[4, 5], 6),
+    (Any[7], 8),
+]
 
-@test gnest[@tagged 11 || 10] == BenchmarkGroup(["1"],
-                                                "a" => BenchmarkGroup(["3"],
-                                                                      (11, "b") => :b),
-                                                9 => gnest[9])
+@test gnest[@tagged 11 || 10] ==
+    BenchmarkGroup(["1"], "a" => BenchmarkGroup(["3"], (11, "b") => :b), 9 => gnest[9])
 
-@test gnest[@tagged "3"] == BenchmarkGroup(["1"], "2" => gnest["2"], 4 => gnest[4], "a" => gnest["a"],
-                                           9 => BenchmarkGroup(["2"], 10 => BenchmarkGroup(["3"])))
+@test gnest[@tagged "3"] == BenchmarkGroup(
+    ["1"],
+    "2" => gnest["2"],
+    4 => gnest[4],
+    "a" => gnest["a"],
+    9 => BenchmarkGroup(["2"], 10 => BenchmarkGroup(["3"])),
+)
 
-@test gnest[@tagged "1" && "2" && "3"] == BenchmarkGroup(["1"], "2" => gnest["2"],
-                                                          9 => BenchmarkGroup(["2"], 10 => BenchmarkGroup(["3"])))
+@test gnest[@tagged "1" && "2" && "3"] == BenchmarkGroup(
+    ["1"], "2" => gnest["2"], 9 => BenchmarkGroup(["2"], 10 => BenchmarkGroup(["3"]))
+)
 
 k = 3 + im
-gnest = BenchmarkGroup(["1"], :hi => BenchmarkGroup([], 1 => 1, k => BenchmarkGroup(["3"], 1 => 1)), 2 => 1)
+gnest = BenchmarkGroup(
+    ["1"], :hi => BenchmarkGroup([], 1 => 1, k => BenchmarkGroup(["3"], 1 => 1)), 2 => 1
+)
 
 @test gnest[@tagged "1"] == gnest
 @test gnest[@tagged "1" && !(:hi)] == BenchmarkGroup(["1"], 2 => 1)
-@test gnest[@tagged :hi && !("3")] == BenchmarkGroup(["1"], :hi => BenchmarkGroup([], 1 => 1))
-@test gnest[@tagged k] == BenchmarkGroup(["1"], :hi => BenchmarkGroup([], k => BenchmarkGroup(["3"], 1 => 1)))
+@test gnest[@tagged :hi && !("3")] ==
+    BenchmarkGroup(["1"], :hi => BenchmarkGroup([], 1 => 1))
+@test gnest[@tagged k] ==
+    BenchmarkGroup(["1"], :hi => BenchmarkGroup([], k => BenchmarkGroup(["3"], 1 => 1)))
 
 # indexing by BenchmarkGroup #
 #----------------------------#
@@ -252,9 +300,12 @@ g["a"] = BenchmarkGroup([], copy(d))
 g["b"] = BenchmarkGroup([], copy(d))
 g["c"] = BenchmarkGroup([], copy(d))
 g["d"] = BenchmarkGroup([], copy(d))
-g["e"] = BenchmarkGroup([], "1" => BenchmarkGroup([], copy(d)),
-                            "2" => BenchmarkGroup([], copy(d)),
-                            "3" => BenchmarkGroup([], copy(d)))
+g["e"] = BenchmarkGroup(
+    [],
+    "1" => BenchmarkGroup([], copy(d)),
+    "2" => BenchmarkGroup([], copy(d)),
+    "3" => BenchmarkGroup([], copy(d)),
+)
 
 x = BenchmarkGroup()
 x["a"] = BenchmarkGroup([], "1" => '1', "3" => '3')
@@ -285,8 +336,8 @@ g2[[1, "a", :b]] = "hello"  # should create higher levels on the fly
 
 @testset "benchmarkset" begin
     g1 = @benchmarkset "test set" begin
-       @case "test case 1" 1 + 1
-       @case "test case 2" 2 + 2
+        @case "test case 1" 1 + 1
+        @case "test case 2" 2 + 2
     end
 
     @test haskey(g1, "test set")
@@ -295,13 +346,13 @@ g2[[1, "a", :b]] = "hello"  # should create higher levels on the fly
 end
 
 @testset "benchmarkset for loop" begin
-  g1 = @benchmarkset "test set" for k in 1:2
-     @case "test case $k" $k + $k
-  end
+    g1 = @benchmarkset "test set" for k in 1:2
+        @case "test case $k" $k + $k
+    end
 
-  @test haskey(g1, "test set")
-  @test haskey(g1["test set"], "test case 1")
-  @test haskey(g1["test set"], "test case 2")
+    @test haskey(g1, "test set")
+    @test haskey(g1["test set"], "test case 1")
+    @test haskey(g1["test set"], "test case 2")
 end
 # pretty printing #
 #-----------------#
@@ -317,18 +368,18 @@ g1["c"] = tc
   "c" => TrialEstimate(1.000 ns)
   "b" => TrialEstimate(4.123 μs)
   "a" => TrialEstimate(32.000 ns)"""
-@test sprint(show, g1; context = :boundto => 1) == """
+@test sprint(show, g1; context=:boundto => 1) == """
 3-element BenchmarkTools.BenchmarkGroup:
   tags: ["1", "2"]
   "c" => TrialEstimate(1.000 ns)
   ⋮"""
-@test sprint(show, g1; context = :limit => false) == """
+@test sprint(show, g1; context=:limit => false) == """
 3-element BenchmarkTools.BenchmarkGroup:
   tags: ["1", "2"]
   "c" => TrialEstimate(1.000 ns)
   "b" => TrialEstimate(4.123 μs)
   "a" => TrialEstimate(32.000 ns)"""
-@test @test_deprecated(sprint(show, g1; context = :limit => 1)) == """
+@test @test_deprecated(sprint(show, g1; context=:limit => 1)) == """
 3-element BenchmarkTools.BenchmarkGroup:
   tags: ["1", "2"]
   "c" => TrialEstimate(1.000 ns)
@@ -339,16 +390,16 @@ g1["c"] = tc
 
 g1 = BenchmarkGroup()
 for T in [Float32, Float64], n in [10, 100], m in [5, 20]
-  g1["sum"][T][n][m] = @benchmarkable sum(x) setup=(x=randn($T, $n, $m))
+    g1["sum"][T][n][m] = @benchmarkable sum(x) setup = (x = randn($T, $n, $m))
 end
 
 # Test that the groups were created:
 for T in [Float32, Float64], n in [10, 100], m in [5, 20]
-  @test "sum" in keys(g1.data)
-  @test string(T) in keys(g1["sum"].data)
-  @test n in keys(g1["sum"][T].data)
-  @test m in keys(g1["sum"][T][n].data)
-  @test typeof(g1["sum"][T][n][m]) == BenchmarkTools.Benchmark
+    @test "sum" in keys(g1.data)
+    @test string(T) in keys(g1["sum"].data)
+    @test n in keys(g1["sum"][T].data)
+    @test m in keys(g1["sum"][T][n].data)
+    @test typeof(g1["sum"][T][n][m]) == BenchmarkTools.Benchmark
 end
 
 # Expected side effect is that accessing groups creates them:
@@ -374,12 +425,11 @@ clear_empty!(g1)
 
 # But other groups should still be present:
 for T in [Float32, Float64], n in [10, 100], m in [5, 20]
-  @test "sum" in keys(g1.data)
-  @test string(T) in keys(g1["sum"].data)
-  @test n in keys(g1["sum"][T].data)
-  @test m in keys(g1["sum"][T][n].data)
-  @test typeof(g1["sum"][T][n][m]) == BenchmarkTools.Benchmark
+    @test "sum" in keys(g1.data)
+    @test string(T) in keys(g1["sum"].data)
+    @test n in keys(g1["sum"][T].data)
+    @test m in keys(g1["sum"][T][n].data)
+    @test typeof(g1["sum"][T][n][m]) == BenchmarkTools.Benchmark
 end
-
 
 # end # module

--- a/test/ParametersTests.jl
+++ b/test/ParametersTests.jl
@@ -6,18 +6,27 @@ using BenchmarkTools: Parameters
 
 @test BenchmarkTools.DEFAULT_PARAMETERS == Parameters()
 
-p = Parameters(seconds = 1, gctrial = false)
+p = Parameters(; seconds=1, gctrial=false)
 oldseconds = BenchmarkTools.DEFAULT_PARAMETERS.seconds
 oldgctrial = BenchmarkTools.DEFAULT_PARAMETERS.gctrial
 BenchmarkTools.DEFAULT_PARAMETERS.seconds = p.seconds
 BenchmarkTools.DEFAULT_PARAMETERS.gctrial = p.gctrial
 @test p == Parameters()
-@test Parameters(p; evals = 3, time_tolerance = .32) == Parameters(evals = 3, time_tolerance = .32)
+@test Parameters(p; evals=3, time_tolerance=0.32) ==
+    Parameters(; evals=3, time_tolerance=0.32)
 BenchmarkTools.DEFAULT_PARAMETERS.seconds = oldseconds
 BenchmarkTools.DEFAULT_PARAMETERS.gctrial = oldgctrial
 
-p = Parameters(seconds = 1, gctrial = false, samples = 2, evals = 2, overhead = 42,
-               gcsample = false, time_tolerance = 0.043, memory_tolerance = 0.15)
+p = Parameters(;
+    seconds=1,
+    gctrial=false,
+    samples=2,
+    evals=2,
+    overhead=42,
+    gcsample=false,
+    time_tolerance=0.043,
+    memory_tolerance=0.15,
+)
 oldseconds = BenchmarkTools.DEFAULT_PARAMETERS.seconds
 oldgctrial = BenchmarkTools.DEFAULT_PARAMETERS.gctrial
 old_time_tolerance = BenchmarkTools.DEFAULT_PARAMETERS.time_tolerance

--- a/test/SerializationTests.jl
+++ b/test/SerializationTests.jl
@@ -3,8 +3,9 @@ module SerializationTests
 using BenchmarkTools
 using Test
 
-eq(x::T, y::T) where {T<:Union{values(BenchmarkTools.SUPPORTED_TYPES)...}} =
-    all(i->eq(getfield(x, i), getfield(y, i)), 1:fieldcount(T))
+function eq(x::T, y::T) where {T<:Union{values(BenchmarkTools.SUPPORTED_TYPES)...}}
+    return all(i -> eq(getfield(x, i), getfield(y, i)), 1:fieldcount(T))
+end
 eq(x::T, y::T) where {T} = isapprox(x, y)
 
 function withtempdir(f::Function)
@@ -12,9 +13,9 @@ function withtempdir(f::Function)
     try
         cd(f, d)
     finally
-        rm(d, force=true, recursive=true)
+        rm(d; force=true, recursive=true)
     end
-    nothing
+    return nothing
 end
 
 @testset "Successful (de)serialization" begin
@@ -47,7 +48,7 @@ end
 
         results = BenchmarkTools.load(tmp)[1]
         @test results isa BenchmarkGroup
-        @test all(v->v isa BenchmarkGroup, values(results.data))
+        @test all(v -> v isa BenchmarkGroup, values(results.data))
     end
 end
 
@@ -79,9 +80,12 @@ end
     withtempdir() do
         tmp = joinpath(pwd(), "tmp.json")
         open(tmp, "w") do f
-            print(f, """
-            {"never":1,"gonna":[{"give":3,"you":4,"up":5}]}
-            """)
+            print(
+                f,
+                """
+       {"never":1,"gonna":[{"give":3,"you":4,"up":5}]}
+       """,
+            )
         end
         try
             BenchmarkTools.load(tmp)

--- a/test/TrialsTests.jl
+++ b/test/TrialsTests.jl
@@ -8,11 +8,11 @@ using Test
 # Trial #
 #########
 
-trial1 = BenchmarkTools.Trial(BenchmarkTools.Parameters(evals = 2))
+trial1 = BenchmarkTools.Trial(BenchmarkTools.Parameters(; evals=2))
 push!(trial1, 2, 1, 4, 5)
 push!(trial1, 21, 0, 41, 51)
 
-trial2 = BenchmarkTools.Trial(BenchmarkTools.Parameters(time_tolerance = 0.15))
+trial2 = BenchmarkTools.Trial(BenchmarkTools.Parameters(; time_tolerance=0.15))
 push!(trial2, 21, 0, 41, 51)
 push!(trial2, 2, 1, 4, 5)
 
@@ -22,18 +22,20 @@ deleteat!(trial2, 3)
 @test length(trial1) == length(trial2) == 2
 sort!(trial2)
 
-@test trial1.params == BenchmarkTools.Parameters(evals = trial1.params.evals)
-@test trial2.params == BenchmarkTools.Parameters(time_tolerance = trial2.params.time_tolerance)
+@test trial1.params == BenchmarkTools.Parameters(; evals=trial1.params.evals)
+@test trial2.params ==
+    BenchmarkTools.Parameters(; time_tolerance=trial2.params.time_tolerance)
 @test trial1.times == trial2.times == [2.0, 21.0]
 @test trial1.gctimes == trial2.gctimes == [1.0, 0.0]
-@test trial1.memory == trial2.memory ==  4
+@test trial1.memory == trial2.memory == 4
 @test trial1.allocs == trial2.allocs == 5
 
 trial2.params = trial1.params
 
 @test trial1 == trial2
 
-@test trial1[2] == push!(BenchmarkTools.Trial(BenchmarkTools.Parameters(evals = 2)), 21, 0, 4, 5)
+@test trial1[2] ==
+    push!(BenchmarkTools.Trial(BenchmarkTools.Parameters(; evals=2)), 21, 0, 4, 5)
 @test trial1[1:end] == trial1
 
 @test time(trial1) == time(trial2) == 2.0
@@ -43,8 +45,9 @@ trial2.params = trial1.params
 @test params(trial1) == params(trial2) == trial1.params
 
 # outlier trimming
-trial3 = BenchmarkTools.Trial(BenchmarkTools.Parameters(), [1, 2, 3, 10, 11],
-                              [1, 1, 1, 1, 1], 1, 1)
+trial3 = BenchmarkTools.Trial(
+    BenchmarkTools.Parameters(), [1, 2, 3, 10, 11], [1, 1, 1, 1, 1], 1, 1
+)
 
 trimtrial3 = rmskew(trial3)
 rmskew!(trial3)
@@ -77,9 +80,27 @@ tmax = maximum(randtrial)
 
 @test time(tmin) == time(randtrial)
 @test gctime(tmin) == gctime(randtrial)
-@test memory(tmin) == memory(tmed) == memory(tmean) == memory(tmax) == memory(tvar) == memory(tstd) == memory(randtrial)
-@test allocs(tmin) == allocs(tmed) == allocs(tmean) == allocs(tmax) == allocs(tvar) == allocs(tstd) == allocs(randtrial)
-@test params(tmin) == params(tmed) == params(tmean) == params(tmax) == params(tvar) == params(tstd) == params(randtrial)
+@test memory(tmin) ==
+    memory(tmed) ==
+    memory(tmean) ==
+    memory(tmax) ==
+    memory(tvar) ==
+    memory(tstd) ==
+    memory(randtrial)
+@test allocs(tmin) ==
+    allocs(tmed) ==
+    allocs(tmean) ==
+    allocs(tmax) ==
+    allocs(tvar) ==
+    allocs(tstd) ==
+    allocs(randtrial)
+@test params(tmin) ==
+    params(tmed) ==
+    params(tmean) ==
+    params(tmax) ==
+    params(tvar) ==
+    params(tstd) ==
+    params(randtrial)
 
 @test tmin <= tmed
 @test tmean <= tmed # this should be true since we called rmoutliers!(randtrial) earlier
@@ -92,12 +113,16 @@ tmax = maximum(randtrial)
 randrange = 1.0:0.01:10.0
 x, y = rand(randrange), rand(randrange)
 
-@test (ratio(x, y) == x/y) && (ratio(y, x) == y/x)
+@test (ratio(x, y) == x / y) && (ratio(y, x) == y / x)
 @test (ratio(x, x) == 1.0) && (ratio(y, y) == 1.0)
 @test ratio(0.0, 0.0) == 1.0
 
-ta = BenchmarkTools.TrialEstimate(BenchmarkTools.Parameters(), rand(), rand(), rand(Int), rand(Int))
-tb = BenchmarkTools.TrialEstimate(BenchmarkTools.Parameters(), rand(), rand(), rand(Int), rand(Int))
+ta = BenchmarkTools.TrialEstimate(
+    BenchmarkTools.Parameters(), rand(), rand(), rand(Int), rand(Int)
+)
+tb = BenchmarkTools.TrialEstimate(
+    BenchmarkTools.Parameters(), rand(), rand(), rand(Int), rand(Int)
+)
 tr = ratio(ta, tb)
 
 @test time(tr) == ratio(time(ta), time(tb))
@@ -113,8 +138,12 @@ tr = ratio(ta, tb)
 # TrialJudgement #
 ##################
 
-ta = BenchmarkTools.TrialEstimate(BenchmarkTools.Parameters(time_tolerance = 0.50, memory_tolerance = 0.50), 0.49, 0.0, 2, 1)
-tb = BenchmarkTools.TrialEstimate(BenchmarkTools.Parameters(time_tolerance = 0.05, memory_tolerance = 0.05), 1.00, 0.0, 1, 1)
+ta = BenchmarkTools.TrialEstimate(
+    BenchmarkTools.Parameters(; time_tolerance=0.50, memory_tolerance=0.50), 0.49, 0.0, 2, 1
+)
+tb = BenchmarkTools.TrialEstimate(
+    BenchmarkTools.Parameters(; time_tolerance=0.05, memory_tolerance=0.05), 1.00, 0.0, 1, 1
+)
 tr = ratio(ta, tb)
 tj_ab = judge(ta, tb)
 tj_r = judge(tr)
@@ -124,8 +153,8 @@ tj_r = judge(tr)
 @test memory(tj_ab) == memory(tj_r) == :regression
 @test tj_ab == tj_r
 
-tj_ab_2 = judge(ta, tb; time_tolerance = 2.0, memory_tolerance = 2.0)
-tj_r_2 = judge(tr; time_tolerance = 2.0, memory_tolerance = 2.0)
+tj_ab_2 = judge(ta, tb; time_tolerance=2.0, memory_tolerance=2.0)
+tj_r_2 = judge(tr; time_tolerance=2.0, memory_tolerance=2.0)
 
 @test tj_ab_2 == tj_r_2
 @test ratio(tj_ab_2) == ratio(tj_r_2)
@@ -181,7 +210,7 @@ tj_r_2 = judge(tr; time_tolerance = 2.0, memory_tolerance = 2.0)
 # pretty printing #
 ###################
 
-@test BenchmarkTools.prettypercent(.3120123) == "31.20%"
+@test BenchmarkTools.prettypercent(0.3120123) == "31.20%"
 
 @test BenchmarkTools.prettydiff(0.0) == "-100.00%"
 @test BenchmarkTools.prettydiff(1.0) == "+0.00%"
@@ -210,30 +239,32 @@ BenchmarkTools.TrialEstimate:
 
 @test sprint(show, ta) == "TrialEstimate(0.490 ns)"
 @test sprint(
-    show, ta;
-    context = IOContext(
-        devnull, :compact => true, :typeinfo => BenchmarkTools.TrialEstimate)
+    show,
+    ta;
+    context=IOContext(devnull, :compact => true, :typeinfo => BenchmarkTools.TrialEstimate),
 ) == "0.490 ns"
 
 @test sprint(show, [ta, tb]) == "BenchmarkTools.TrialEstimate[0.490 ns, 1.000 ns]"
 
 trial1sample = BenchmarkTools.Trial(BenchmarkTools.Parameters(), [1], [1], 1, 1)
-@test try display(trial1sample); true catch e false end
+@test try
+    display(trial1sample)
+    true
+catch e
+    false
+end
 
 @static if VERSION < v"1.6-"
-
-@test sprint(show, "text/plain", [ta, tb]) == """
-2-element Array{BenchmarkTools.TrialEstimate,1}:
- 0.490 ns
- 1.000 ns"""
+    @test sprint(show, "text/plain", [ta, tb]) == """
+    2-element Array{BenchmarkTools.TrialEstimate,1}:
+     0.490 ns
+     1.000 ns"""
 
 else
-
-@test sprint(show, "text/plain", [ta, tb]) == """
-2-element Vector{BenchmarkTools.TrialEstimate}:
- 0.490 ns
- 1.000 ns"""
-
+    @test sprint(show, "text/plain", [ta, tb]) == """
+    2-element Vector{BenchmarkTools.TrialEstimate}:
+     0.490 ns
+     1.000 ns"""
 end
 
 trial = BenchmarkTools.Trial(BenchmarkTools.Parameters(), [1.0, 1.01], [0.0, 0.0], 0, 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,16 @@
 using Aqua
 using BenchmarkTools
+using JuliaFormatter
 using Test
 
 print("Testing code quality...")
 took_seconds = @elapsed Aqua.test_all(BenchmarkTools)
+println("done (took ", took_seconds, " seconds)")
+
+print("Testing code formatting...")
+took_seconds = @elapsed @test JuliaFormatter.format(
+    BenchmarkTools; verbose=false, overwrite=false
+)
 println("done (took ", took_seconds, " seconds)")
 
 print("Testing Parameters...")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,13 @@ print("Testing code quality...")
 took_seconds = @elapsed Aqua.test_all(BenchmarkTools)
 println("done (took ", took_seconds, " seconds)")
 
-print("Testing code formatting...")
-took_seconds = @elapsed @test JuliaFormatter.format(
-    BenchmarkTools; verbose=false, overwrite=false
-)
-println("done (took ", took_seconds, " seconds)")
+if VERSION >= v"1.6"
+    print("Testing code formatting...")
+    took_seconds = @elapsed @test JuliaFormatter.format(
+        BenchmarkTools; verbose=false, overwrite=false
+    )
+    println("done (took ", took_seconds, " seconds)")
+end
 
 print("Testing Parameters...")
 took_seconds = @elapsed include("ParametersTests.jl")


### PR DESCRIPTION
Other prominent JuliaCI repos like PkgTemplates.jl already use the [BlueStyle](https://github.com/invenia/BlueStyle). This PR does the same for BenchmarkTools.jl. More precisely, it
- sets up JuliaFormatter to use BlueStyle on this repo with the `.JuliaFormatter.toml` file
- applies automatic formatting to the existing code (mostly spacing modifications, all in the second commit)
- adds a test checking that formatting is correct in `test/runtests.jl`, along with a test-specific dependency in `Project.toml`
- adds a BlueStyle badge to `README.md`