### PR TITLE
[WIP] Add seed to BenchmarkGroup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -8,6 +8,7 @@ using Statistics
 using UUIDs: uuid4
 using Printf
 using Profile
+using Random
 
 const BENCHMARKTOOLS_VERSION = v"1.0.0"
 

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -145,6 +145,7 @@ function Base.run(group::BenchmarkGroup, args...; verbose::Bool=false, pad="", k
         gcscrub() # run GC before running group, even if individual benchmarks don't manually GC
         i = 1
         for id in keys(group)
+            Random.seed!(group.seed >= 0 ? group.seed : nothing)
             @logmsg(
                 ProgressLevel, "Benchmarking", progress = ndone / nleaves, _id = progressid
             )
@@ -245,6 +246,7 @@ function tune!(group::BenchmarkGroup; verbose::Bool=false, pad="", kwargs...)
         gcscrub() # run GC before running group, even if individual benchmarks don't manually GC
         i = 1
         for id in keys(group)
+            Random.seed!(group.seed >= 0 ? group.seed : nothing)
             @logmsg(ProgressLevel, "Tuning", progress = ndone / nleaves, _id = progressid)
             verbose && println(pad, "($(i)/$(length(group))) tuning ", repr(id), "...")
             took_seconds = @elapsed tune!(

--- a/test/GroupsTests.jl
+++ b/test/GroupsTests.jl
@@ -432,4 +432,22 @@ for T in [Float32, Float64], n in [10, 100], m in [5, 20]
     @test typeof(g1["sum"][T][n][m]) == BenchmarkTools.Benchmark
 end
 
+results = Dict("a" => Int[], "b" => Int[])
+bg = BenchmarkGroup(
+    "a" => @benchmarkable(push!(results["a"], rand(Int)), samples = 10, evals = 1),
+    "b" => @benchmarkable(push!(results["b"], rand(Int)), samples = 10, evals = 1),
+    ;
+    seed=1234,
+)
+run(bg)
+@test results["a"] == results["b"]
+bg = BenchmarkGroup(
+    "a" => @benchmarkable(push!(results["a"], rand(Int)), samples = 10, evals = 1),
+    "b" => @benchmarkable(push!(results["b"], rand(Int)), samples = 10, evals = 1),
+    ;
+    # No seed specified
+)
+run(bg)
+@test results["a"] != results["b"]
+
 # end # module


### PR DESCRIPTION
Partial solution for #201 . Since it needs to be serializable, I opted for just a seed number. `seed!` is not super well documented, so `Int` may not be the perfect type, but it's pretty handy. Negative seeds appear to be invalid, so I could use that as a stand-in for `nothing`, as `Union{Int, Nothing}` ruined serialization.

* [x] PR
* [ ] Complete tests
* [ ] Documentation
