### PR TITLE
Reexport `std` and `var` from `Statistics`

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -353,13 +353,20 @@ BenchmarkTools.Trial
   allocs: Int64 19
 ```
 
-As you can see from the above, a couple of different timing estimates are pretty-printed with the `Trial`. You can calculate these estimates yourself using the `minimum`, `median`, `mean`, `maximum`, and `std` functions:
+As you can see from the above, a couple of different timing estimates are pretty-printed with the `Trial`. You can calculate these estimates yourself using the `minimum`, `maximum`, `median`, `mean`, and `std` functions:
 
 ```julia
 julia> minimum(t)
 BenchmarkTools.TrialEstimate: 
   time:             26.549 μs
   gctime:           0.000 ns (0.00%)
+  memory:           16.36 KiB
+  allocs:           19
+
+julia> maximum(t)
+BenchmarkTools.TrialEstimate: 
+  time:             1.503 ms
+  gctime:           1.401 ms (93.21%)
   memory:           16.36 KiB
   allocs:           19
 
@@ -374,13 +381,6 @@ julia> mean(t)
 BenchmarkTools.TrialEstimate: 
   time:             31.777 μs
   gctime:           415.686 ns (1.31%)
-  memory:           16.36 KiB
-  allocs:           19
-
-julia> maximum(t)
-BenchmarkTools.TrialEstimate: 
-  time:             1.503 ms
-  gctime:           1.401 ms (93.21%)
   memory:           16.36 KiB
   allocs:           19
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -353,7 +353,7 @@ BenchmarkTools.Trial
   allocs: Int64 19
 ```
 
-As you can see from the above, a couple of different timing estimates are pretty-printed with the `Trial`. You can calculate these estimates yourself using the `minimum`, `maximum`, `median`, `mean`, and `std` functions:
+As you can see from the above, a couple of different timing estimates are pretty-printed with the `Trial`. You can calculate these estimates yourself using the `minimum`, `maximum`, `median`, `mean`, and `std` functions (Note that `median`, `mean`, and `std` are reexported in `BenchmarkTools` from `Statistics`):
 
 ```julia
 julia> minimum(t)

--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -36,6 +36,8 @@ export gctime,
     isimprovement,
     median,
     mean,
+    std,
+    var,
     rmskew!,
     rmskew,
     trim

--- a/test/GroupsTests.jl
+++ b/test/GroupsTests.jl
@@ -2,7 +2,6 @@
 
 using BenchmarkTools
 using BenchmarkTools: TrialEstimate, Parameters
-using Statistics
 using Test
 
 seteq(a, b) = length(a) == length(b) == length(intersect(a, b))

--- a/test/TrialsTests.jl
+++ b/test/TrialsTests.jl
@@ -1,7 +1,6 @@
 module TrialsTests
 
 using BenchmarkTools
-using Statistics
 using Test
 
 #########


### PR DESCRIPTION
Fixes: #146 (part 2)

The original request was to just add a note in the docs about reexports from `Statistics`: https://github.com/JuliaCI/BenchmarkTools.jl/issues/146#issuecomment-1732649667

But then I found we were missing some re-exports that the docs assume exist. So I added those back in as originally proposed in the above issue.

This PR also  removes unnecessary `Statistics` imports in the tests. FYI @maleadt, This reverts your change from #294 to restore my change from #149.

If we don't want to go with the reexport strategy, that's also fine with me. I just want things to be consistent.