### PR TITLE
Allow loading saved benchmark results from version <= 1.3.2

### DIFF
--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -50,10 +50,11 @@ function recover(x::Vector)
     for i in 1:fc
         ft = fieldtype(T, i)
         fn = String(fieldname(T, i))
-        if fn == "evals_set"
-            xsi = false
-        elseif ft <: get(SUPPORTED_TYPES, nameof(ft), Union{})
-            xsi = recover(fields[fn])
+        if ft <: get(SUPPORTED_TYPES, nameof(ft), Union{})
+            xsi = if fn == "evals_set" && !haskey(fields, fn)
+            else
+                recover(fields[fn])
+            end
         else
             xsi = convert(ft, fields[fn])
         end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -51,13 +51,13 @@ function recover(x::Vector)
         ft = fieldtype(T, i)
         fn = String(fieldname(T, i))
         if ft <: get(SUPPORTED_TYPES, nameof(ft), Union{})
+            recover(fields[fn])
+        else
             xsi = if fn == "evals_set" && !haskey(fields, fn)
                 false
             else
-                recover(fields[fn])
+                convert(ft, fields[fn])
             end
-        else
-            xsi = convert(ft, fields[fn])
         end
         if T == BenchmarkGroup && xsi isa Dict
             for (k, v) in copy(xsi)

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -51,7 +51,7 @@ function recover(x::Vector)
         ft = fieldtype(T, i)
         fn = String(fieldname(T, i))
         if ft <: get(SUPPORTED_TYPES, nameof(ft), Union{})
-            recover(fields[fn])
+            xsi = recover(fields[fn])
         else
             xsi = if fn == "evals_set" && !haskey(fields, fn)
                 false

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -50,7 +50,9 @@ function recover(x::Vector)
     for i in 1:fc
         ft = fieldtype(T, i)
         fn = String(fieldname(T, i))
-        if ft <: get(SUPPORTED_TYPES, nameof(ft), Union{})
+        if fn == "evals_set"
+            xsi = false
+        elseif ft <: get(SUPPORTED_TYPES, nameof(ft), Union{})
             xsi = recover(fields[fn])
         else
             xsi = convert(ft, fields[fn])

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -52,6 +52,7 @@ function recover(x::Vector)
         fn = String(fieldname(T, i))
         if ft <: get(SUPPORTED_TYPES, nameof(ft), Union{})
             xsi = if fn == "evals_set" && !haskey(fields, fn)
+                false
             else
                 recover(fields[fn])
             end

--- a/test/SerializationTests.jl
+++ b/test/SerializationTests.jl
@@ -99,4 +99,11 @@ end
     @test_throws ArgumentError BenchmarkTools.recover([1])
 end
 
+@testset "Backwards Comppatibility with evals_set" begin
+    json_string = "[{\"Julia\":\"1.11.0-DEV.1116\",\"BenchmarkTools\":\"1.4.0\"},[[\"Parameters\",{\"gctrial\":true,\"time_tolerance\":0.05,\"samples\":10000,\"evals\":1,\"gcsample\":false,\"seconds\":5.0,\"overhead\":0.0,\"memory_tolerance\":0.01}]]]"
+    json_io = IOBuffer(json_string)
+
+    @test BenchmarkTools.load(json_io) == [Parameters(5.0, 10000, 1, false, 0.0, true, false, 0.05, 0.01)]
+end
+
 end # module

--- a/test/SerializationTests.jl
+++ b/test/SerializationTests.jl
@@ -104,6 +104,11 @@ end
     json_io = IOBuffer(json_string)
 
     @test BenchmarkTools.load(json_io) == [Parameters(5.0, 10000, 1, false, 0.0, true, false, 0.05, 0.01)]
+
+    json_string = "[{\"Julia\":\"1.11.0-DEV.1116\",\"BenchmarkTools\":\"1.4.0\"},[[\"Parameters\",{\"gctrial\":true,\"time_tolerance\":0.05,\"evals_set\":true,\"samples\":10000,\"evals\":1,\"gcsample\":false,\"seconds\":5.0,\"overhead\":0.0,\"memory_tolerance\":0.01}]]]"
+    json_io = IOBuffer(json_string)
+
+    @test BenchmarkTools.load(json_io) == [Parameters(5.0, 10000, 1, true, 0.0, true, false, 0.05, 0.01)]
 end
 
 end # module

--- a/test/SerializationTests.jl
+++ b/test/SerializationTests.jl
@@ -103,12 +103,14 @@ end
     json_string = "[{\"Julia\":\"1.11.0-DEV.1116\",\"BenchmarkTools\":\"1.4.0\"},[[\"Parameters\",{\"gctrial\":true,\"time_tolerance\":0.05,\"samples\":10000,\"evals\":1,\"gcsample\":false,\"seconds\":5.0,\"overhead\":0.0,\"memory_tolerance\":0.01}]]]"
     json_io = IOBuffer(json_string)
 
-    @test BenchmarkTools.load(json_io) == [BenchmarkTools.Parameters(5.0, 10000, 1, false, 0.0, true, false, 0.05, 0.01)]
+    @test BenchmarkTools.load(json_io) ==
+        [BenchmarkTools.Parameters(5.0, 10000, 1, false, 0.0, true, false, 0.05, 0.01)]
 
     json_string = "[{\"Julia\":\"1.11.0-DEV.1116\",\"BenchmarkTools\":\"1.4.0\"},[[\"Parameters\",{\"gctrial\":true,\"time_tolerance\":0.05,\"evals_set\":true,\"samples\":10000,\"evals\":1,\"gcsample\":false,\"seconds\":5.0,\"overhead\":0.0,\"memory_tolerance\":0.01}]]]"
     json_io = IOBuffer(json_string)
 
-    @test BenchmarkTools.load(json_io) == [BenchmarkTools.Parameters(5.0, 10000, 1, true, 0.0, true, false, 0.05, 0.01)]
+    @test BenchmarkTools.load(json_io) ==
+        [BenchmarkTools.Parameters(5.0, 10000, 1, true, 0.0, true, false, 0.05, 0.01)]
 end
 
 end # module

--- a/test/SerializationTests.jl
+++ b/test/SerializationTests.jl
@@ -103,12 +103,12 @@ end
     json_string = "[{\"Julia\":\"1.11.0-DEV.1116\",\"BenchmarkTools\":\"1.4.0\"},[[\"Parameters\",{\"gctrial\":true,\"time_tolerance\":0.05,\"samples\":10000,\"evals\":1,\"gcsample\":false,\"seconds\":5.0,\"overhead\":0.0,\"memory_tolerance\":0.01}]]]"
     json_io = IOBuffer(json_string)
 
-    @test BenchmarkTools.load(json_io) == [Parameters(5.0, 10000, 1, false, 0.0, true, false, 0.05, 0.01)]
+    @test BenchmarkTools.load(json_io) == [BenchmarkTools.Parameters(5.0, 10000, 1, false, 0.0, true, false, 0.05, 0.01)]
 
     json_string = "[{\"Julia\":\"1.11.0-DEV.1116\",\"BenchmarkTools\":\"1.4.0\"},[[\"Parameters\",{\"gctrial\":true,\"time_tolerance\":0.05,\"evals_set\":true,\"samples\":10000,\"evals\":1,\"gcsample\":false,\"seconds\":5.0,\"overhead\":0.0,\"memory_tolerance\":0.01}]]]"
     json_io = IOBuffer(json_string)
 
-    @test BenchmarkTools.load(json_io) == [Parameters(5.0, 10000, 1, true, 0.0, true, false, 0.05, 0.01)]
+    @test BenchmarkTools.load(json_io) == [BenchmarkTools.Parameters(5.0, 10000, 1, true, 0.0, true, false, 0.05, 0.01)]
 end
 
 end # module


### PR DESCRIPTION
After `evals_set` was added to the `Parameters` struct, it no longer was possible to load old files. Given the simplicity of the fix seems worthwhile.

I set the default to false, as that seems to replicate the behaviour of BenchmarkTools before this field was added.