### PR TITLE
Support for named tuple destructuring

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -346,7 +346,12 @@ function collectvars(ex::Expr, vars::Vector{Symbol}=Symbol[])
         if isa(lhs, Symbol)
             push!(vars, lhs)
         elseif isa(lhs, Expr) && lhs.head == :tuple
-            append!(vars, lhs.args)
+            args = lhs.args
+            if !isempty(args) && isa(first(args), Expr)
+                # named tuple destructuring
+                args = first(args).args
+            end
+            append!(vars, args)
         end
     elseif (ex.head == :comprehension || ex.head == :generator)
         arg = ex.args[1]

--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -216,10 +216,12 @@ tune!(b)
     "good")
 @test_throws UndefVarError local_var
 @benchmark some_var = "whatever" teardown = (@test_throws UndefVarError some_var)
-@benchmark foo, bar = "good", "good" setup = (foo = "bad"; bar = "bad") teardown = (@test foo ==
-                                                                                          "good" &&
-    bar ==
-                                                                                          "good")
+@benchmark foo, bar = "good", "good" setup = (foo = "bad"; bar = "bad") teardown = @test(
+    foo == "good" && bar == "good"
+)
+@benchmark (; foo, bar) = (foo="good", bar="good") setup = (foo = "bad"; bar = "bad") teardown = @test(
+    foo == "good" && bar == "good"
+)
 
 # test variable assignment with `@benchmark(args...)` form
 @benchmark(


### PR DESCRIPTION
e.g.
```
@benchmark let 
    (; x, y) = $p
    f(x,y)
end
```
currently fails at macro expansion
