### PR TITLE
Raise minimum Julia version to 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,9 +24,6 @@ jobs:
         os:
           - ubuntu-latest
         include:
-          - version: '1.5'
-            arch: x64
-            os: ubuntu-20.04
           - version: '1.7'
             arch: x64
             os: ubuntu-20.04

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
           - '1.6'
           - '1'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 version = "1.6.0"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -12,6 +13,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Aqua = "0.8"
+Compat = ">= 4.11.0"
 JSON = "0.18, 0.19, 0.20, 0.21"
 JuliaFormatter = "1"
 Logging = "<0.0.1, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BenchmarkTools"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -20,7 +20,7 @@ Profile = "<0.0.1, 1"
 Statistics = "<0.0.1, 1"
 Test = "<0.0.1, 1"
 UUIDs = "<0.0.1, 1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -12,7 +12,7 @@ using Profile
 const BENCHMARKTOOLS_VERSION = if VERSION >= v"1.9"
     pkgversion(BenchmarkTools)
 else
-    v"1.4.0"
+    v"1.6.0"
 end
 
 ##############

--- a/src/BenchmarkTools.jl
+++ b/src/BenchmarkTools.jl
@@ -8,12 +8,7 @@ using Statistics
 using UUIDs: uuid4
 using Printf
 using Profile
-
-const BENCHMARKTOOLS_VERSION = if VERSION >= v"1.9"
-    pkgversion(BenchmarkTools)
-else
-    v"1.6.0"
-end
+using Compat
 
 ##############
 # Parameters #

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -1,5 +1,5 @@
 const VERSIONS = Dict(
-    "Julia" => string(VERSION), "BenchmarkTools" => string(BENCHMARKTOOLS_VERSION)
+    "Julia" => string(VERSION), "BenchmarkTools" => pkgversion(BenchmarkTools)
 )
 
 # TODO: Add any new types as they're added


### PR DESCRIPTION
Split out from #347, LinuxPerf doesn't support 1.0 as it depends on PrettyTables which doesn't. Also, buildkite doesn't seem to support it either.
1.0 seems sufficiently old that it seems fine to me to drop support.