### PR TITLE
Don't profile the gcsrub of gctrial when profiling

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -721,8 +721,9 @@ macro bprofile(args...)
                 end
             )
             $BenchmarkTools.Profile.clear()
+            $tmp.params.gctrial && $BenchmarkTools.gcscrub()
             #TODO: improve @bprofile to only measure the running code and none of the setup
-            $BenchmarkTools.@profile $BenchmarkTools.run($tmp, $tmp.params; warmup=false)
+            $BenchmarkTools.@profile $BenchmarkTools.run($tmp, $tmp.params; warmup=false, gctrial=false)
         end,
     )
 end

--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -317,7 +317,7 @@ str = String(take!(io))
 b = @bprofile 1 + 1 gctrial = true
 Profile.print(IOContext(io, :displaysize => (24, 200)))
 str = String(take!(io))
-@test occursin("gcscrub", str)
+@test !occursin("gcscrub", str)
 
 ########
 # misc #


### PR DESCRIPTION
It's not ideal to move gctrial this early as it will miss a bit of garbage, e.g. the stuff allocated at the beginning of `_run` but this shouldn't be a big issue.

As a side note, it's hard to improve bprofile much more in terms of not profiling irrelevant stuff. I have some code that only profiles between setup and teardown, but as samples are generally short that approach doesn't profile much if anything, making it pretty useless.