### PR TITLE
"evaluations" -> "evaluations each" when printing `Trial`

### DIFF
--- a/src/trials.jl
+++ b/src/trials.jl
@@ -377,8 +377,7 @@ function Base.show(io::IO, ::MIME"text/plain", t::Trial)
         else
             ""
         end,
-        " each".
-        ".\n",
+        " per sample.\n"
     )
 
     perm = sortperm(t.times)

--- a/src/trials.jl
+++ b/src/trials.jl
@@ -377,6 +377,7 @@ function Base.show(io::IO, ::MIME"text/plain", t::Trial)
         else
             ""
         end,
+        " each".
         ".\n",
     )
 

--- a/src/trials.jl
+++ b/src/trials.jl
@@ -377,7 +377,7 @@ function Base.show(io::IO, ::MIME"text/plain", t::Trial)
         else
             ""
         end,
-        " per sample.\n"
+        " per sample.\n",
     )
 
     perm = sortperm(t.times)

--- a/test/TrialsTests.jl
+++ b/test/TrialsTests.jl
@@ -268,7 +268,7 @@ end
 
 trial = BenchmarkTools.Trial(BenchmarkTools.Parameters(), [1.0, 1.01], [0.0, 0.0], 0, 0)
 @test sprint(show, "text/plain", trial) == """
-BenchmarkTools.Trial: 2 samples with 1 evaluation.
+BenchmarkTools.Trial: 2 samples with 1 evaluation per sample.
  Range (min … max):  1.000 ns … 1.010 ns  ┊ GC (min … max): 0.00% … 0.00%
  Time  (median):     1.005 ns             ┊ GC (median):    0.00%
  Time  (mean ± σ):   1.005 ns ± 0.007 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%


### PR DESCRIPTION
This makes a bit more sense for first time users IMO, otherwise it's not obvious what a sample and evaluation are.  