### PR TITLE
Fix compilation and interpolation memory leaks

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -380,15 +380,15 @@ function quasiquote!(ex::Expr, vars::Vector{Symbol}, vals::Vector{Expr})
 end
 
 """
-    rename(expr::Expr, renames::Dict{Symbol, Symbol})
+    substitute_syms(expr::Expr, old_new::Dict{Symbol, Symbol})
 
-Rename variables in `expr` using substitutions in `renames`.
+Substitute symbols in `expr` using substitutions in `old_new`.
 """
-rename(ex, _...) = ex
-rename(ex::Symbol, renames::Dict{Symbol, Symbol}) = get(renames, ex, ex)
-function rename(ex::Expr, renames::Dict{Symbol, Symbol})
+substitute_syms(ex, _...) = ex
+substitute_syms(ex::Symbol, old_new::Dict{Symbol, Symbol}) = get(old_new, ex, ex)
+function substitute_syms(ex::Expr, old_new::Dict{Symbol, Symbol})
     if ex.head !== :quote
-        return Expr(ex.head, map(x -> rename(x, renames), ex.args)...)
+        return Expr(ex.head, map(x -> substitute_syms(x, old_new), ex.args)...)
     else
         return ex
     end
@@ -536,8 +536,20 @@ function generate_benchmark_definition(
     eval_module, out_vars, setup_vars, quote_vars, quote_vals, core, setup, teardown, params
 )
     @nospecialize
-    renames = Dict{Symbol, Symbol}(map(((i, var),) -> var => Symbol(:norm, i), enumerate(quote_vars)))
-    samplefunc_key = (rename(core, renames), rename(setup, renames), rename(teardown, renames), length(quote_vars))
+    normalize_syms = Dict{Symbol, Symbol}(map(((i, var),) -> var => Symbol(:__normal_sym__, i), enumerate(quote_vars)))
+    #We cache the generated benchmark function to avoid recompiling it every time.
+    #We use several keys to cache the generated benchmark function.
+    #Because out_vars and setup_vars are derived from core and setup, we do not
+    #need to use these in the cache. Because quote_vars are identified
+    #positionally, we need only cache their length. We rename the quote vars for caching
+    #because they are generated with gensym()
+    samplefunc_key = [
+        eval_module,
+        substitute_syms(core, normalize_syms),
+        substitute_syms(setup, normalize_syms),
+        substitute_syms(teardown, normalize_syms),
+        length(quote_vars)
+    ]
     samplefunc = get!(cache, samplefunc_key) do
         corefunc = gensym("core")
         samplefunc = gensym("sample")

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -555,7 +555,7 @@ function generate_benchmark_definition(
             end
         )
     end
-    return Core.eval(
+    samplefunc = Core.eval(
         eval_module,
         quote
             @noinline $(signature_def) = begin
@@ -589,9 +589,9 @@ function generate_benchmark_definition(
                 )
                 return __time, __gctime, __memory, __allocs, __return_val
             end
-            $BenchmarkTools.Benchmark($(samplefunc), $(quote_vals), $(params))
         end,
     )
+    Benchmark(samplefunc, quote_vals, params)
 end
 
 ######################

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -471,6 +471,8 @@ function benchmarkable_parts(args)
     quote_vars = Symbol[]
     quote_vals = Expr[]
     core = quasiquote!(core, quote_vars, quote_vals)
+    setup = quasiquote!(setup, quote_vars, quote_vals)
+    teardown = quasiquote!(teardown, quote_vars, quote_vals)
 
     return core, setup, teardown, quote_vars, quote_vals, params
 end


### PR DESCRIPTION
Fixes #339. Fixes a memory leak in interpolated variables from `setup` and `teardown`, continuing what was started in #265. Additionally, adds a cache of already-compiled sampler functions, so that wrapping a `@benchmark` in a for-loop doesn't compile separate functions each iteration.

Here's an example:

### Setup
```
julia> using BenchmarkTools, Printf

julia> function f(n)
           x = rand(Int, n)
           target = sort(x)
           y = copy(target)
           @belapsed sort!($y) setup=($y == $target || error("Bad sort"); copyto!($y, $x)) evals=1 gctrial=false samples=3
       end
f (generic function with 1 method)

julia> function meminfo_julia()
           GC.gc()
           @printf "GC total:  %9.3f MiB\n" Base.gc_total_bytes(Base.gc_num())/2^20
           @printf "GC live:   %9.3f MiB\n" Base.gc_live_bytes()/2^20
           @printf "JIT:       %9.3f MiB\n" Base.jit_total_bytes()/2^20
           @printf "Max. RSS:  %9.3f MiB\n" Sys.maxrss()/2^20
       end
```

### Main Branch

```
julia> meminfo_julia()
GC total:    121.857 MiB
GC live:      14.555 MiB
JIT:           0.384 MiB
Max. RSS:    338.000 MiB

julia> times = f.(1594323:1594323+100);

julia> meminfo_julia()
GC total:  10147.292 MiB
GC live:    3695.383 MiB
JIT:           1.550 MiB
Max. RSS:   4152.938 MiB
```

### After Fixing Setup Leaks

```
julia> meminfo_julia()
GC total:     77.615 MiB
GC live:      14.343 MiB
JIT:           0.165 MiB
Max. RSS:    305.688 MiB

julia> times = f.(1594323:1594323+100);

julia> meminfo_julia()
GC total:  10112.637 MiB
GC live:       9.663 MiB
JIT:           1.326 MiB
Max. RSS:    495.234 MiB
```

### After Fixing Redundant Compilation

```
julia> meminfo_julia()
GC total:     77.695 MiB
GC live:      14.409 MiB
JIT:           0.165 MiB
Max. RSS:    306.406 MiB

julia> times = f.(1594323:1594323+100);

julia> meminfo_julia()
GC total:  10011.679 MiB
GC live:       8.914 MiB
JIT:           0.416 MiB
Max. RSS:    476.047 MiB
```
