### PR TITLE
deprecate @benchmarkset

### DIFF
--- a/src/groups.jl
+++ b/src/groups.jl
@@ -368,6 +368,9 @@ const benchmark_stack = []
 
 Create a benchmark set, or multiple benchmark sets if a `for` loop is provided.
 
+!!! danger "`@benchmarkset` is deprecated."
+    Instead, add to `group = BenchmarkGroup()` using `group[key] = @benchmark...`
+
 # Examples
 
 ```julia
@@ -378,7 +381,7 @@ end
 """
 macro benchmarkset(title, ex)
     Base.depwarn(
-        "`BenchmarkTools.@benchmarkset` is deprecated. Add to `group = BenchmarkGroup()` using `group[key] = @benchmark...`",
+        "`BenchmarkTools.@benchmarkset` is deprecated. Instead, add to `group = BenchmarkGroup()` using `group[key] = @benchmark...`",
         :benchmarkset,
     )
     return esc(benchmarkset_m(title, ex))
@@ -388,6 +391,9 @@ end
     @case title <expr to benchmark> [setup=<setup expr>]
 
 Mark an expression as a benchmark case. Must be used inside [`@benchmarkset`](@ref).
+
+!!! danger "`@benchmarkset` is deprecated."
+    Instead, add to `group = BenchmarkGroup()` using `group[key] = @benchmark...`
 """
 macro case(title, xs...)
     return esc(:($(Symbol("#suite#"))[$title] = @benchmarkable $(xs...)))

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -377,6 +377,7 @@ end
 ```
 """
 macro benchmarkset(title, ex)
+    Base.depwarn("`BenchmarkTools.@benchmarkset` is deprecated. Add to `group = BenchmarkGroup()` using `group[key] = @benchmark...`", :benchmarkset)
     return esc(benchmarkset_m(title, ex))
 end
 

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -377,7 +377,10 @@ end
 ```
 """
 macro benchmarkset(title, ex)
-    Base.depwarn("`BenchmarkTools.@benchmarkset` is deprecated. Add to `group = BenchmarkGroup()` using `group[key] = @benchmark...`", :benchmarkset)
+    Base.depwarn(
+        "`BenchmarkTools.@benchmarkset` is deprecated. Add to `group = BenchmarkGroup()` using `group[key] = @benchmark...`",
+        :benchmarkset,
+    )
     return esc(benchmarkset_m(title, ex))
 end
 


### PR DESCRIPTION
Following the reasoning in https://github.com/JuliaCI/PkgBenchmark.jl/issues/9#issuecomment-257952067 that macros are confusing, and considering that the functionality is equivalent to existing code paths but the macro is the topic of three issues and has not been fixed since it's introduction, deprecate the @benchmarkset macro. There is [documentation](https://juliaci.github.io/BenchmarkTools.jl/stable/manual/#Defining-benchmark-suites) on how to define benchmark suites using the standard interface, so those who experience trouble with the benchmarkset macro should use the recommended approach in the docs. fixes https://github.com/JuliaCI/BenchmarkTools.jl/issues/369, fixes https://github.com/JuliaCI/BenchmarkTools.jl/issues/343, fixes https://github.com/JuliaCI/BenchmarkTools.jl/issues/279