### PR TITLE
Removing the need for Evals_set parameter

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -295,7 +295,7 @@ function tune!(
     pad="",
     kwargs...,
 )
-    if !p.evals_set
+    if p.evals==nothing
         estimate = ceil(Int, minimum(lineartrial(b, p; kwargs...)))
         b.params.evals = guessevals(estimate)
     end
@@ -317,9 +317,6 @@ function prunekwargs(args...)
         for ex in params
             if isa(ex, Expr) && ex.head == :(=)
                 ex.head = :kw
-                if ex.args[1] == :evals
-                    push!(params, :(evals_set = true))
-                end
             end
         end
         if isa(core, Expr) && core.head == :kw

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -295,7 +295,7 @@ function tune!(
     pad="",
     kwargs...,
 )
-    if p.evals==nothing
+    if p.evals==-1
         estimate = ceil(Int, minimum(lineartrial(b, p; kwargs...)))
         b.params.evals = guessevals(estimate)
     end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -16,7 +16,7 @@ mutable struct Parameters
     memory_tolerance::Float64
 end
 
-const DEFAULT_PARAMETERS = Parameters(5.0, 10000, nothing, 0, true, false, 0.05, 0.01)
+const DEFAULT_PARAMETERS = Parameters(5.0, 10000, -1, 0, true, false, 0.05, 0.01)
 
 function Parameters(;
     seconds=DEFAULT_PARAMETERS.seconds,

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -9,7 +9,6 @@ mutable struct Parameters
     seconds::Float64
     samples::Int
     evals::Int
-    evals_set::Bool
     overhead::Float64
     gctrial::Bool
     gcsample::Bool
@@ -17,13 +16,12 @@ mutable struct Parameters
     memory_tolerance::Float64
 end
 
-const DEFAULT_PARAMETERS = Parameters(5.0, 10000, 1, false, 0, true, false, 0.05, 0.01)
+const DEFAULT_PARAMETERS = Parameters(5.0, 10000, nothing, 0, true, false, 0.05, 0.01)
 
 function Parameters(;
     seconds=DEFAULT_PARAMETERS.seconds,
     samples=DEFAULT_PARAMETERS.samples,
     evals=DEFAULT_PARAMETERS.evals,
-    evals_set=DEFAULT_PARAMETERS.evals_set,
     overhead=DEFAULT_PARAMETERS.overhead,
     gctrial=DEFAULT_PARAMETERS.gctrial,
     gcsample=DEFAULT_PARAMETERS.gcsample,
@@ -34,7 +32,6 @@ function Parameters(;
         seconds,
         samples,
         evals,
-        evals_set,
         overhead,
         gctrial,
         gcsample,
@@ -84,7 +81,6 @@ function Base.copy(p::Parameters)
         p.seconds,
         p.samples,
         p.evals,
-        p.evals_set,
         p.overhead,
         p.gctrial,
         p.gcsample,

--- a/test/SerializationTests.jl
+++ b/test/SerializationTests.jl
@@ -99,22 +99,8 @@ end
     @test_throws ArgumentError BenchmarkTools.recover([1])
 end
 
-@testset "Backwards Comppatibility with evals_set" begin
-    json_string = "[{\"Julia\":\"1.11.0-DEV.1116\",\"BenchmarkTools\":\"1.4.0\"},[[\"Parameters\",{\"gctrial\":true,\"time_tolerance\":0.05,\"samples\":10000,\"evals\":1,\"gcsample\":false,\"seconds\":5.0,\"overhead\":0.0,\"memory_tolerance\":0.01}]]]"
-    json_io = IOBuffer(json_string)
-
-    @test BenchmarkTools.load(json_io) ==
-        [BenchmarkTools.Parameters(5.0, 10000, 1, false, 0.0, true, false, 0.05, 0.01)]
-
-    json_string = "[{\"Julia\":\"1.11.0-DEV.1116\",\"BenchmarkTools\":\"1.4.0\"},[[\"Parameters\",{\"gctrial\":true,\"time_tolerance\":0.05,\"evals_set\":true,\"samples\":10000,\"evals\":1,\"gcsample\":false,\"seconds\":5.0,\"overhead\":0.0,\"memory_tolerance\":0.01}]]]"
-    json_io = IOBuffer(json_string)
-
-    @test BenchmarkTools.load(json_io) ==
-        [BenchmarkTools.Parameters(5.0, 10000, 1, true, 0.0, true, false, 0.05, 0.01)]
-end
-
 @testset "Inf in Paramters struct" begin
-    params = BenchmarkTools.Parameters(Inf, 10000, 1, false, Inf, true, false, Inf, Inf)
+    params = BenchmarkTools.Parameters(Inf, 10000, 1, Inf, true, false, Inf, Inf)
 
     io = IOBuffer()
     BenchmarkTools.save(io, params)

--- a/test/SerializationTests.jl
+++ b/test/SerializationTests.jl
@@ -99,8 +99,22 @@ end
     @test_throws ArgumentError BenchmarkTools.recover([1])
 end
 
+@testset "Backwards Comppatibility with evals_set" begin
+    json_string = "[{\"Julia\":\"1.11.0-DEV.1116\",\"BenchmarkTools\":\"1.4.0\"},[[\"Parameters\",{\"gctrial\":true,\"time_tolerance\":0.05,\"samples\":10000,\"evals\":1,\"gcsample\":false,\"seconds\":5.0,\"overhead\":0.0,\"memory_tolerance\":0.01}]]]"
+    json_io = IOBuffer(json_string)
+
+    @test BenchmarkTools.load(json_io) ==
+        [BenchmarkTools.Parameters(5.0, 10000, 1, false, 0.0, true, false, 0.05, 0.01)]
+
+    json_string = "[{\"Julia\":\"1.11.0-DEV.1116\",\"BenchmarkTools\":\"1.4.0\"},[[\"Parameters\",{\"gctrial\":true,\"time_tolerance\":0.05,\"evals_set\":true,\"samples\":10000,\"evals\":1,\"gcsample\":false,\"seconds\":5.0,\"overhead\":0.0,\"memory_tolerance\":0.01}]]]"
+    json_io = IOBuffer(json_string)
+
+    @test BenchmarkTools.load(json_io) ==
+        [BenchmarkTools.Parameters(5.0, 10000, 1, true, 0.0, true, false, 0.05, 0.01)]
+end
+
 @testset "Inf in Paramters struct" begin
-    params = BenchmarkTools.Parameters(Inf, 10000, 1, Inf, true, false, Inf, Inf)
+    params = BenchmarkTools.Parameters(Inf, 10000, 1, false, Inf, true, false, Inf, Inf)
 
     io = IOBuffer()
     BenchmarkTools.save(io, params)


### PR DESCRIPTION
Sets evals to -1 as default and does tuning only when number of evals have not been explicitly set. I will get on to working on the required changes in the tests if this seems satisfactory.