### PR TITLE
Stop tuning when benchmark is deemed slow enough

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -232,6 +232,9 @@ function _lineartrial(b::Benchmark, p::Parameters=b.params; maxevals=RESOLUTION,
         estimates[evals] = s[1]
         prev_allocs = s[4]
         completed += 1
+        # If several samples exceed RESOLUTION, more samples cannot change the
+        # number of evaluations chosen by guessevals.
+        completed >= 3 && minimum(view(estimates, 1:completed)) > RESOLUTION && break
         ((time() - start_time) > params.seconds) && break
     end
     resize!(estimates, completed)
@@ -252,7 +255,9 @@ end
 
 # The tuning process is as follows:
 #
-#   1. Using `lineartrial`, take one sample of the benchmark for each `evals` in `1:RESOLUTION`.
+#   1. Using `lineartrial`, take one sample of the benchmark for each `evals` in
+#      `1:RESOLUTION`. Stop after three samples if they all take longer than
+#      `RESOLUTION`, because additional samples cannot change the result in step 3.
 #
 #   2. Extract the minimum sample found in this trial. Hopefully, this value will be
 #      reasonably close to the true benchmark time. At the very least, we can be certain

--- a/test/ExecutionTests.jl
+++ b/test/ExecutionTests.jl
@@ -86,6 +86,13 @@ b_fail = @benchmarkable test_length_and_push!(y) setup = (y = randn(2))
 b_pass = @benchmarkable test_length_and_push!(y) setup = (y = randn(2)) evals = 1
 @test tune!(b_pass) isa BenchmarkTools.Benchmark
 
+# Tuning stops after three samples when a benchmark is slow enough to use one evaluation.
+
+b_slow = @benchmarkable sleep(0.01)
+@test length(BenchmarkTools.lineartrial(b_slow, b_slow.params)) == 3
+tune!(b_slow)
+@test params(b_slow).evals == 1
+
 #######
 # run #
 #######


### PR DESCRIPTION
Trying to deal with tuning taking a silly long time for some functions (it took like 5s to tune a ~10us function to decide it should run with 3 evals and then the actual benchmark finishes very quickly) This seems like one obvious way to speed it up:

:robot: :

`lineartrial` normally tests every evaluation count from 1 through
`RESOLUTION`. This makes tuning unnecessarily expensive for slow
benchmarks, even though they will use one evaluation per sample.

Once three samples all take longer than `RESOLUTION`, further samples
cannot change the result from `guessevals`. Stop the trial at that point
while preserving the existing behavior for faster benchmarks.