### PR TITLE
Run two GC sweeps in gcscrub instead of three on Julia 1.10+

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -1,11 +1,11 @@
-# Trigger several successive GC sweeps. This is more comprehensive than running just a
-# single sweep, since freeable objects may need more than one sweep to be appropriately
-# marked and freed.
+# Two sweeps: the second reclaims memory released by finalizers (they run after the
+# first sweep) and completes generational promotion of survivors, keeping later
+# collections cheap. A third sweep has no measurable effect on Julia 1.10-1.13.
 function gcscrub()
     GC.gc()
     GC.gc()
-    GC.gc()
     @static if VERSION < v"1.10"
+        GC.gc()
         GC.gc()
     end
 end


### PR DESCRIPTION
Measured on 1.10.11, 1.11.9, 1.12.6 and 1.13-rc1 with a ~1 GiB live heap:

- One sweep frees all ordinary garbage, but leaves survivors
  unpromoted (the next few young collections re-mark them, with
  20-90 ms pauses) and does not reclaim memory released by finalizers,
  which only run after the sweep.
- Two sweeps complete generational promotion (follow-up collections
  are a uniform 1-2 ms) and reclaim finalizer-released memory.
- A third sweep changes nothing measurable on any tested version.

Pre-1.10 keeps four sweeps, which was not measured.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
